### PR TITLE
Implement data extraction from pdf and docx

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
+	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/labstack/echo/v4 v4.13.3 h1:pwhpCPrTl5qry5HRdM5FwdXnhXSLSY+WE+YQSeCaa
 github.com/labstack/echo/v4 v4.13.3/go.mod h1:o90YNEeQWjDozo584l7AwhJMHN0bOC4tAfg+Xox9q5g=
 github.com/labstack/gommon v0.4.2 h1:F8qTUNXgG1+6WQmqoUWnz8WiEU60mXVVw0P4ht1WRA0=
 github.com/labstack/gommon v0.4.2/go.mod h1:QlUFxVM+SNXhDL/Z7YhocGIBYOiwB0mXm1+1bAPHPyU=
+github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728 h1:QwWKgMY28TAXaDl+ExRDqGQltzXqN/xypdKP86niVn8=
+github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728/go.mod h1:1fEHWurg7pvf5SG6XNE5Q8UZmOwex51Mkx3SLhrW5B4=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=

--- a/internal/core/interfaces/secondary/data_extractor.go
+++ b/internal/core/interfaces/secondary/data_extractor.go
@@ -1,0 +1,24 @@
+package secondary
+
+import (
+	"context"
+	"io"
+)
+
+// ExtractionResult contains the normalized text extracted from a file and
+// lightweight metadata that may be useful for downstream processing.
+type ExtractionResult struct {
+	Text       string // plain text ready to be sent to the AI pipeline
+	Pages      int    // number of pages (when known, e.g. PDF)
+	SourceType string // detected source type: "pdf" | "docx" | "text" | ...
+}
+
+// DataExtractor is a port for extracting text content from arbitrary binary data.
+// Implementations might handle PDFs, Word documents, plain text, or other formats.
+type DataExtractor interface {
+	// ExtractText extracts textual content from the provided reader. The
+	// contentType parameter can be used to guide the extraction (for example
+	// "application/pdf" or "text/plain"). It returns an ExtractionResult or
+	// an error if extraction fails.
+	ExtractText(ctx context.Context, r io.Reader, contentType string) (*ExtractionResult, error)
+}

--- a/internal/infra/extractor/docx_extractor.go
+++ b/internal/infra/extractor/docx_extractor.go
@@ -1,0 +1,95 @@
+package extractor
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/xml"
+	"errors"
+	"io"
+	"strings"
+
+	sec "github.com/misalima/edunex-backend/internal/core/interfaces/secondary"
+)
+
+// extractDOCX extracts text from a DOCX file provided as a byte slice.
+// It looks for word/document.xml inside the DOCX ZIP and parses XML,
+// preserving paragraph breaks and runs of text.
+func extractDOCX(ctx context.Context, data []byte) (*sec.ExtractionResult, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return nil, ErrCorruptedFile
+	}
+
+	var docFile *zip.File
+	for _, f := range zr.File {
+		if f.Name == "word/document.xml" {
+			docFile = f
+			break
+		}
+	}
+	if docFile == nil {
+		return nil, ErrUnsupportedFormat
+	}
+
+	rc, err := docFile.Open()
+	if err != nil {
+		return nil, ErrCorruptedFile
+	}
+	defer func() { _ = rc.Close() }()
+
+	// Read content
+	b, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, ErrCorruptedFile
+	}
+
+	// Basic XML parsing: look for <w:p> (paragraph) and <w:t> (text)
+	decoder := xml.NewDecoder(bytes.NewReader(b))
+	var sb strings.Builder
+	var inText bool
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		tok, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, ErrCorruptedFile
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			local := t.Name.Local
+			if local == "p" {
+				if sb.Len() > 0 {
+					sb.WriteString("\n\n")
+				}
+			}
+			if local == "br" {
+				sb.WriteString("\n")
+			}
+			if local == "t" {
+				inText = true
+			}
+		case xml.EndElement:
+			local := t.Name.Local
+			if local == "t" {
+				inText = false
+			}
+		case xml.CharData:
+			if inText {
+				sb.WriteString(string(t))
+			}
+		}
+	}
+
+	out := normalizeText(sb.String())
+	return &sec.ExtractionResult{Text: out, Pages: 0, SourceType: "docx"}, nil
+}

--- a/internal/infra/extractor/errors.go
+++ b/internal/infra/extractor/errors.go
@@ -1,0 +1,10 @@
+package extractor
+
+import "errors"
+
+var (
+	ErrUnsupportedFormat = errors.New("unsupported format")
+	ErrTooLarge          = errors.New("file exceeds size limit")
+	ErrCorruptedFile     = errors.New("corrupted or unreadable file")
+	ErrExtractionFailed  = errors.New("extraction failed")
+)

--- a/internal/infra/extractor/extractor.go
+++ b/internal/infra/extractor/extractor.go
@@ -1,0 +1,102 @@
+package extractor
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	sec "github.com/misalima/edunex-backend/internal/core/interfaces/secondary"
+)
+
+type Extractor struct {
+	// MaxBytes allows overriding the default read limit for tests or special cases.
+	MaxBytes int64
+}
+
+func NewExtractor() *Extractor {
+	return &Extractor{MaxBytes: DefaultMaxBytes}
+}
+
+// ExtractText implements sec.DataExtractor.
+func (e *Extractor) ExtractText(ctx context.Context, r io.Reader, contentType string) (*sec.ExtractionResult, error) {
+	// read up to MaxBytes+1 to detect oversize
+	maxBytes := e.MaxBytes
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxBytes
+	}
+
+	lr := &io.LimitedReader{R: r, N: maxBytes + 1}
+	data, err := io.ReadAll(lr)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrExtractionFailed, err)
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, ErrTooLarge
+	}
+
+	// decide type: 1) trusted contentType 2) detect PDF 3) detect DOCX (zip+word/document.xml)
+	ct := strings.ToLower(strings.TrimSpace(contentType))
+	if ct != "" {
+		if strings.Contains(ct, "pdf") {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			return extractPDF(ctx, data)
+		}
+		// For DOCX rely on the official mime (wordprocessingml). Checking for
+		// the literal "docx" in the content-type is unreliable and unnecessary.
+		if strings.Contains(ct, "wordprocessingml") {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			return extractDOCX(ctx, data)
+		}
+	}
+
+	// detect PDF by header
+	if len(data) >= 4 && string(data[:4]) == "%PDF" {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		return extractPDF(ctx, data)
+	}
+
+	// detect zip (DOCX)
+	if len(data) >= 4 && bytes.Equal(data[:4], []byte{0x50, 0x4b, 0x03, 0x04}) {
+		// open zip from buffer and check for word/document.xml
+		zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+		if err == nil {
+			for _, f := range zr.File {
+				if f.Name == "word/document.xml" {
+					if err := ctx.Err(); err != nil {
+						return nil, err
+					}
+					// Note: we reopen the zip inside extractDOCX. This means
+					// we parse the in-memory bytes twice (once here to detect
+					// the presence of document.xml and again inside
+					// extractDOCX). For the MVP this is acceptable because
+					// the file is buffered in memory (max 10MB). If needed we
+					// can optimize by creating the zip.Reader once and passing
+					// it to extractDOCX.
+					return extractDOCX(ctx, data)
+				}
+			}
+		}
+	}
+
+	// fallback: if content looks like plain text
+	detected := http.DetectContentType(data)
+	// For the MVP be conservative: accept only explicit text/plain as a
+	// fallback. Other text/* types (html, csv) are rejected to avoid edge
+	// cases where non-lesson-plan files slip through.
+	if strings.HasPrefix(detected, "text/plain") {
+		txt := normalizeText(string(data))
+		return &sec.ExtractionResult{Text: txt, Pages: 0, SourceType: "text"}, nil
+	}
+
+	return nil, ErrUnsupportedFormat
+}

--- a/internal/infra/extractor/extractor_test.go
+++ b/internal/infra/extractor/extractor_test.go
@@ -1,0 +1,84 @@
+package extractor
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestDetectDocxAndExtract(t *testing.T) {
+	// create an in-memory docx (zip) with word/document.xml
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	f, err := zw.Create("word/document.xml")
+	if err != nil {
+		t.Fatalf("create zip entry: %v", err)
+	}
+	_, err = io.WriteString(f, `<?xml version="1.0" encoding="UTF-8"?><w:document><w:body><w:p><w:r><w:t>Hello</w:t></w:r></w:p><w:p><w:r><w:t>World</w:t></w:r></w:p></w:body></w:document>`)
+	if err != nil {
+		t.Fatalf("write xml: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+
+	ex := NewExtractor()
+	res, err := ex.ExtractText(context.Background(), bytes.NewReader(buf.Bytes()), "")
+	if err != nil {
+		t.Fatalf("ExtractText failed: %v", err)
+	}
+	if res.SourceType != "docx" {
+		t.Fatalf("expected docx, got %s", res.SourceType)
+	}
+	if !strings.Contains(res.Text, "Hello") {
+		t.Fatalf("expected 'Hello' in text, got: %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "World") {
+		t.Fatalf("expected 'World' in text, got: %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "\n\n") {
+		t.Fatalf("expected paragraph breaks in text, got: %q", res.Text)
+	}
+}
+
+func TestDetectPdfByHeaderOnly(t *testing.T) {
+	data := []byte("%PDF-1.4\n%\u00e2\u00e3\u00cf\u00d3\n1 0 obj\n<< /Type /Catalog >>")
+	ex := NewExtractor()
+	res, err := ex.ExtractText(context.Background(), bytes.NewReader(data), "")
+	if res != nil {
+		t.Fatalf("expected no result, got %+v", res)
+	}
+	if !errors.Is(err, ErrCorruptedFile) {
+		t.Fatalf("expected ErrCorruptedFile, got %v", err)
+	}
+}
+
+func TestUnsupportedFormat(t *testing.T) {
+	ex := NewExtractor()
+	_, err := ex.ExtractText(context.Background(), bytes.NewReader([]byte{0x00, 0x01, 0x02, 0x03}), "")
+	if !errors.Is(err, ErrUnsupportedFormat) {
+		t.Fatalf("expected ErrUnsupportedFormat, got %v", err)
+	}
+}
+
+func TestTooLarge(t *testing.T) {
+	ex := &Extractor{MaxBytes: 10}
+	data := bytes.Repeat([]byte("a"), 20)
+	_, err := ex.ExtractText(context.Background(), bytes.NewReader(data), "text/plain")
+	if !errors.Is(err, ErrTooLarge) {
+		t.Fatalf("expected ErrTooLarge, got %v", err)
+	}
+}
+
+func TestCorruptedDocx(t *testing.T) {
+	ex := NewExtractor()
+	data := []byte{0x50, 0x4b, 0x03, 0x04, 0x00}
+	_, err := ex.ExtractText(context.Background(), bytes.NewReader(data), "application/vnd.openxmlformats-officedocument.wordprocessingml.document")
+	if !errors.Is(err, ErrCorruptedFile) {
+		t.Fatalf("expected ErrCorruptedFile, got %v", err)
+	}
+}

--- a/internal/infra/extractor/limits.go
+++ b/internal/infra/extractor/limits.go
@@ -1,0 +1,7 @@
+package extractor
+
+const (
+	// DefaultMaxBytes defines the maximum number of bytes to read from an
+	// incoming file for extraction. 10MB is the chosen default for the MVP.
+	DefaultMaxBytes = 10 << 20 // 10 MB
+)

--- a/internal/infra/extractor/normalize.go
+++ b/internal/infra/extractor/normalize.go
@@ -1,0 +1,29 @@
+package extractor
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	horizontalSpaceRe = regexp.MustCompile(`[ \t]+`)
+	verticalSpaceRe   = regexp.MustCompile(`\n{3,}`)
+)
+
+// normalizeText removes extra whitespace while preserving paragraph structure.
+func normalizeText(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+
+	s = horizontalSpaceRe.ReplaceAllString(s, " ")
+
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimSpace(line)
+	}
+	s = strings.Join(lines, "\n")
+
+	s = verticalSpaceRe.ReplaceAllString(s, "\n\n")
+
+	return strings.TrimSpace(s)
+}

--- a/internal/infra/extractor/pdf_extractor.go
+++ b/internal/infra/extractor/pdf_extractor.go
@@ -1,0 +1,70 @@
+package extractor
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+
+	pdf "github.com/ledongthuc/pdf"
+	sec "github.com/misalima/edunex-backend/internal/core/interfaces/secondary"
+)
+
+// extractPDF uses github.com/ledongthuc/pdf to extract plain text from PDF
+// bytes. It opens the PDF directly from an in-memory reader to avoid
+// temporary files and improve concurrency.
+func extractPDF(ctx context.Context, data []byte) (*sec.ExtractionResult, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	// open directly from memory
+	r, err := pdf.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrCorruptedFile, err)
+	}
+	numPages := r.NumPage()
+
+	var buf bytes.Buffer
+	// r.GetPlainText returns an io.Reader with the text content
+	pr, err := r.GetPlainText()
+	if err != nil {
+		// fallback: try to read per page
+		for i := 1; i <= numPages; i++ {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			p := r.Page(i)
+			if p.V.IsNull() {
+				continue
+			}
+			contentStr, err := p.GetPlainText(nil)
+			if err != nil {
+				continue
+			}
+			buf.WriteString(contentStr)
+			// use a simple, LLM-friendly page separator
+			buf.WriteString("\n---\n")
+		}
+		text := normalizeText(buf.String())
+		return &sec.ExtractionResult{Text: text, Pages: numPages, SourceType: "pdf"}, nil
+	}
+
+	// Respect ctx during the copy: run copy in a goroutine and select on ctx.Done().
+	done := make(chan error, 1)
+	go func() {
+		_, err := io.Copy(&buf, pr)
+		done <- err
+	}()
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case err := <-done:
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrExtractionFailed, err)
+		}
+	}
+
+	text := normalizeText(buf.String())
+	return &sec.ExtractionResult{Text: text, Pages: numPages, SourceType: "pdf"}, nil
+}


### PR DESCRIPTION
This pull request introduces a new, extensible data extraction system for handling text extraction from various file types (PDF, DOCX, and plain text). It defines a generic interface for data extractors, implements robust extraction logic for PDF and DOCX files (with normalization and error handling), and includes comprehensive tests for edge cases and error scenarios.

The most important changes are:

**Core Extraction Interface and Types**
- Introduced the `DataExtractor` interface and the `ExtractionResult` struct in `data_extractor.go`, providing a standard contract for extracting normalized text and metadata from arbitrary binary files.

**Extractor Implementation and File Type Detection**
- Implemented the main `Extractor` in `extractor.go`, which detects file type (PDF, DOCX, or plain text) via content type or file header, enforces size limits, and delegates to specialized extractors.
- Added error definitions in `errors.go` and a configurable maximum file size in `limits.go`. [[1]](diffhunk://#diff-aa1b59a37943d15b463c7c4a58109a068eaac8485757678cdbea130111295a99R1-R10) [[2]](diffhunk://#diff-81aabd36b2412e5136cbe1c45050a805353ec68555539b39dc2db875c4656d17R1-R7)

**Format-Specific Extraction Logic**
- Added robust PDF extraction using the `github.com/ledongthuc/pdf` library, with fallback per-page extraction and context cancellation support in `pdf_extractor.go`. [[1]](diffhunk://#diff-6b2b3043236a25ec03e9afce69979a15bc22531f221b65619f050cbfe5c24c15R1-R70) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R39)
- Implemented DOCX extraction (parsing `word/document.xml` from ZIP) with paragraph and line break preservation in `docx_extractor.go`.

**Text Normalization**
- Provided a `normalizeText` utility in `normalize.go` to standardize whitespace and paragraph structure in extracted text.

**Testing and Validation**
- Added comprehensive tests in `extractor_test.go` covering DOCX and PDF detection, extraction, size limits, and error cases (unsupported/corrupted files).

This PR closes https://github.com/misalima/edunex-backend/issues/31 https://github.com/misalima/edunex-backend/issues/30 https://github.com/misalima/edunex-backend/issues/32 https://github.com/misalima/edunex-backend/issues/33