### PR TITLE
refactor: extract GORM models to internal/infra/postgres/models

### DIFF
--- a/internal/infra/postgres/analysis_job_repository.go
+++ b/internal/infra/postgres/analysis_job_repository.go
@@ -7,41 +7,9 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/misalima/edunex-backend/internal/core/domain"
-	"gorm.io/datatypes"
+	"github.com/misalima/edunex-backend/internal/infra/postgres/models"
 	"gorm.io/gorm"
 )
-
-type AnalysisJob struct {
-	ID           uuid.UUID `gorm:"type:uuid;primaryKey"`
-	LessonPlanID uuid.UUID `gorm:"type:uuid;uniqueIndex"`
-	Status       string    `gorm:"index"`
-	Attempts     int
-	ErrorMessage string
-	CreatedAt    time.Time
-	StartedAt    *time.Time
-	FinishedAt   *time.Time
-}
-
-// TableName specifies the table name for GORM
-func (AnalysisJob) TableName() string {
-	return "analysis_jobs"
-}
-
-func (m *AnalysisJob) toDomain() *domain.AnalysisJob {
-	if m == nil {
-		return nil
-	}
-	return &domain.AnalysisJob{
-		ID:           m.ID,
-		LessonPlanID: m.LessonPlanID,
-		Status:       m.Status,
-		Attempts:     m.Attempts,
-		ErrorMessage: m.ErrorMessage,
-		CreatedAt:    m.CreatedAt,
-		StartedAt:    m.StartedAt,
-		FinishedAt:   m.FinishedAt,
-	}
-}
 
 // AnalysisJobRepository handles database operations for analysis jobs
 type AnalysisJobRepository struct {
@@ -77,7 +45,7 @@ func (r *AnalysisJobRepository) UpsertAnalysisJob(ctx context.Context, lessonPla
 
 	// If no rows were affected, fetch the existing job ID
 	if result.RowsAffected == 0 {
-		var existingJob AnalysisJob
+		var existingJob models.AnalysisJobModel
 		if err := r.db.WithContext(ctx).
 			Where("lesson_plan_id = ?", lessonPlanID).
 			First(&existingJob).Error; err != nil {
@@ -92,7 +60,7 @@ func (r *AnalysisJobRepository) UpsertAnalysisJob(ctx context.Context, lessonPla
 // FetchPendingJob fetches a single pending job and atomically marks it as processing
 // Uses SELECT FOR UPDATE SKIP LOCKED to avoid race conditions
 func (r *AnalysisJobRepository) FetchPendingJob(ctx context.Context) (*domain.AnalysisJob, error) {
-	var job AnalysisJob
+	var job models.AnalysisJobModel
 
 	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// Raw query to use SELECT FOR UPDATE SKIP LOCKED
@@ -117,8 +85,8 @@ func (r *AnalysisJobRepository) FetchPendingJob(ctx context.Context) (*domain.An
 					"status":     domain.JobProcessing,
 					"started_at": now,
 				}).Error; err != nil {
-				return fmt.Errorf("failed to mark job as processing: %w", err)
-			}
+					return fmt.Errorf("failed to mark job as processing: %w", err)
+				}
 		}
 
 		return nil
@@ -132,13 +100,13 @@ func (r *AnalysisJobRepository) FetchPendingJob(ctx context.Context) (*domain.An
 		return nil, nil // No pending jobs found
 	}
 
-	return job.toDomain(), nil
+	return job.ToDomain(), nil
 }
 
 // FetchPendingJobByID fetches a specific pending job by ID and atomically marks it as processing.
 // Returns nil if the job is not in pending status (already claimed by another worker).
 func (r *AnalysisJobRepository) FetchPendingJobByID(ctx context.Context, jobID uuid.UUID) (*domain.AnalysisJob, error) {
-	var job AnalysisJob
+	var job models.AnalysisJobModel
 
 	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// Fetch specific job with lock if pending
@@ -161,8 +129,8 @@ func (r *AnalysisJobRepository) FetchPendingJobByID(ctx context.Context, jobID u
 					"status":     domain.JobProcessing,
 					"started_at": now,
 				}).Error; err != nil {
-				return fmt.Errorf("failed to mark job as processing: %w", err)
-			}
+					return fmt.Errorf("failed to mark job as processing: %w", err)
+				}
 		}
 
 		return nil
@@ -176,13 +144,13 @@ func (r *AnalysisJobRepository) FetchPendingJobByID(ctx context.Context, jobID u
 		return nil, nil // Job not found or not pending
 	}
 
-	return job.toDomain(), nil
+	return job.ToDomain(), nil
 }
 
 // MarkJobDone marks a job as completed
 func (r *AnalysisJobRepository) MarkJobDone(ctx context.Context, jobID uuid.UUID) error {
 	now := time.Now()
-	result := r.db.WithContext(ctx).Model(&AnalysisJob{}).
+	result := r.db.WithContext(ctx).Model(&models.AnalysisJobModel{}).
 		Where("id = ?", jobID).
 		Updates(map[string]interface{}{
 			"status":        domain.JobDone,
@@ -199,7 +167,7 @@ func (r *AnalysisJobRepository) MarkJobDone(ctx context.Context, jobID uuid.UUID
 
 // MarkJobFailed marks a job as failed and increments attempt count
 func (r *AnalysisJobRepository) MarkJobFailed(ctx context.Context, jobID uuid.UUID, errorMsg string, maxAttempts int) error {
-	var job AnalysisJob
+	var job models.AnalysisJobModel
 
 	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// Fetch current job
@@ -234,7 +202,7 @@ func (r *AnalysisJobRepository) MarkJobFailed(ctx context.Context, jobID uuid.UU
 
 // GetJobByLessonPlanID fetches a job by lesson plan ID
 func (r *AnalysisJobRepository) GetJobByLessonPlanID(ctx context.Context, lessonPlanID uuid.UUID) (*domain.AnalysisJob, error) {
-	var job AnalysisJob
+	var job models.AnalysisJobModel
 
 	if err := r.db.WithContext(ctx).
 		Where("lesson_plan_id = ?", lessonPlanID).
@@ -245,7 +213,7 @@ func (r *AnalysisJobRepository) GetJobByLessonPlanID(ctx context.Context, lesson
 		return nil, fmt.Errorf("failed to fetch job: %w", err)
 	}
 
-	return job.toDomain(), nil
+	return job.ToDomain(), nil
 }
 
 // CleanupStaleProcessingJobs marks processing jobs that haven't been updated as pending (recovery from crashes)
@@ -253,6 +221,7 @@ func (r *AnalysisJobRepository) CleanupStaleProcessingJobs(ctx context.Context, 
 	staleBefore := time.Now().Add(-staleThreshold)
 
 	result := r.db.WithContext(ctx).
+		Model(&models.AnalysisJobModel{}).
 		Where("status = ? AND started_at < ?", domain.JobProcessing, staleBefore).
 		Updates(map[string]interface{}{
 			"status":     domain.JobPending,
@@ -275,7 +244,7 @@ func (r *AnalysisJobRepository) GetJobStatistics(ctx context.Context) (map[strin
 
 	var counts []StatusCount
 	if err := r.db.WithContext(ctx).
-		Model(&AnalysisJob{}).
+		Model(&models.AnalysisJobModel{}).
 		Select("status, COUNT(*) as count").
 		Group("status").
 		Scan(&counts).Error; err != nil {
@@ -302,21 +271,13 @@ func (r *AnalysisJobRepository) SaveAnalysisAndMarkDone(ctx context.Context, ana
 	// Insert analysis model (which implements InsertAnalysis) and mark job done in one transaction
 	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// Insert the analysis
-		model := &lessonPlanAnalysisModel{
-			ID:             analysis.ID,
-			LessonPlanID:   analysis.LessonPlanID,
-			Title:          analysis.Title,
-			Subject:        analysis.Subject,
-			GradeLevel:     analysis.GradeLevel,
-			AlignmentScore: analysis.AlignmentScore,
-			Feedback:       analysis.Feedback,
-			Metadata:       datatypes.JSON(analysis.Metadata),
-			Suggestions:    datatypes.JSON(analysis.Suggestions),
-			CreatedAt:      analysis.CreatedAt,
+		model := models.FromDomainAnalysis(analysis)
+		if model.ID == uuid.Nil {
+			model.ID = uuid.New()
 		}
 
 		// Delete any existing analysis for this lesson plan to prevent unique constraint violation on re-analysis
-		if err := tx.Where("lesson_plan_id = ?", analysis.LessonPlanID).Delete(&lessonPlanAnalysisModel{}).Error; err != nil {
+		if err := tx.Where("lesson_plan_id = ?", analysis.LessonPlanID).Delete(&models.LessonPlanAnalysisModel{}).Error; err != nil {
 			return fmt.Errorf("failed to delete existing analysis: %w", err)
 		}
 
@@ -326,7 +287,7 @@ func (r *AnalysisJobRepository) SaveAnalysisAndMarkDone(ctx context.Context, ana
 
 		// Mark job as done
 		now := time.Now()
-		if err := tx.Model(&AnalysisJob{}).
+		if err := tx.Model(&models.AnalysisJobModel{}).
 			Where("id = ?", jobID).
 			Updates(map[string]interface{}{
 				"status":        domain.JobDone,
@@ -344,7 +305,7 @@ func (r *AnalysisJobRepository) SaveAnalysisAndMarkDone(ctx context.Context, ana
 
 // GetJobByID fetches an analysis job by ID
 func (r *AnalysisJobRepository) GetJobByID(ctx context.Context, jobID uuid.UUID) (*domain.AnalysisJob, error) {
-	var job AnalysisJob
+	var job models.AnalysisJobModel
 
 	if err := r.db.WithContext(ctx).
 		Where("id = ?", jobID).
@@ -355,5 +316,6 @@ func (r *AnalysisJobRepository) GetJobByID(ctx context.Context, jobID uuid.UUID)
 		return nil, fmt.Errorf("failed to fetch job by ID: %w", err)
 	}
 
-	return job.toDomain(), nil
+	return job.ToDomain(), nil
 }
+

--- a/internal/infra/postgres/lesson_plan_analysis_repository.go
+++ b/internal/infra/postgres/lesson_plan_analysis_repository.go
@@ -3,72 +3,18 @@ package postgres
 import (
 	"context"
 	"errors"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/misalima/edunex-backend/internal/core/domain"
 	"github.com/misalima/edunex-backend/internal/core/domain_errors"
 	"github.com/misalima/edunex-backend/internal/core/interfaces/secondary"
 	"github.com/misalima/edunex-backend/internal/infra/logger"
+	"github.com/misalima/edunex-backend/internal/infra/postgres/models"
 	"go.uber.org/zap"
-	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
 
 var _ secondary.LessonPlanAnalysisLoader = (*LessonPlanAnalysisRepository)(nil)
-
-type lessonPlanAnalysisModel struct {
-	ID             uuid.UUID      `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
-	LessonPlanID   uuid.UUID      `gorm:"type:uuid;not null;uniqueIndex:idx_lpa_lesson_plan_id"`
-	Title          string         `gorm:"type:text;not null"`
-	Subject        string         `gorm:"type:text;not null"`
-	GradeLevel     string         `gorm:"type:text;not null"`
-	AlignmentScore int            `gorm:"type:integer;not null;check:alignment_score >= 0 AND alignment_score <= 100"`
-	Feedback       string         `gorm:"type:text;not null"`
-	Metadata       datatypes.JSON `gorm:"type:jsonb;not null"`
-	Suggestions    datatypes.JSON `gorm:"type:jsonb;not null"`
-	CreatedAt      time.Time      `gorm:"column:created_at;autoCreateTime"`
-}
-
-func (lessonPlanAnalysisModel) TableName() string {
-	return "lesson_plan_analyses"
-}
-
-func (m *lessonPlanAnalysisModel) toDomain() *domain.LessonPlanAnalysis {
-	if m == nil {
-		return nil
-	}
-	return &domain.LessonPlanAnalysis{
-		ID:             m.ID,
-		LessonPlanID:   m.LessonPlanID,
-		Title:          m.Title,
-		Subject:        m.Subject,
-		GradeLevel:     m.GradeLevel,
-		AlignmentScore: m.AlignmentScore,
-		Feedback:       m.Feedback,
-		Metadata:       string(m.Metadata),
-		Suggestions:    string(m.Suggestions),
-		CreatedAt:      m.CreatedAt,
-	}
-}
-
-func fromDomainAnalysis(lpa *domain.LessonPlanAnalysis) *lessonPlanAnalysisModel {
-	if lpa == nil {
-		return nil
-	}
-	return &lessonPlanAnalysisModel{
-		ID:             lpa.ID,
-		LessonPlanID:   lpa.LessonPlanID,
-		Title:          lpa.Title,
-		Subject:        lpa.Subject,
-		GradeLevel:     lpa.GradeLevel,
-		AlignmentScore: lpa.AlignmentScore,
-		Feedback:       lpa.Feedback,
-		Metadata:       datatypes.JSON(lpa.Metadata),
-		Suggestions:    datatypes.JSON(lpa.Suggestions),
-		CreatedAt:      lpa.CreatedAt,
-	}
-}
 
 type LessonPlanAnalysisRepository struct {
 	db *gorm.DB
@@ -86,7 +32,7 @@ func (r *LessonPlanAnalysisRepository) InsertAnalysis(ctx context.Context, analy
 		return domain_errors.NewBadRequestMsg("lesson_plan_id is required")
 	}
 
-	m := fromDomainAnalysis(analysis)
+	m := models.FromDomainAnalysis(analysis)
 	if m.ID == uuid.Nil {
 		m.ID = uuid.New()
 	}
@@ -118,7 +64,7 @@ func (r *LessonPlanAnalysisRepository) GetAnalysisByLessonPlanID(ctx context.Con
 
 	logger.Log.Debug("fetching lesson plan analysis", zap.String("lesson_plan_id", lessonPlanID.String()))
 
-	m := &lessonPlanAnalysisModel{}
+	m := &models.LessonPlanAnalysisModel{}
 	if err := r.db.WithContext(ctx).First(m, "lesson_plan_id = ?", lessonPlanID).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			logger.Log.Debug("lesson plan analysis not found", zap.String("lesson_plan_id", lessonPlanID.String()))
@@ -134,5 +80,6 @@ func (r *LessonPlanAnalysisRepository) GetAnalysisByLessonPlanID(ctx context.Con
 		zap.String("analysis_id", m.ID.String()),
 		zap.String("lesson_plan_id", m.LessonPlanID.String()))
 
-	return m.toDomain(), nil
+	return m.ToDomain(), nil
 }
+

--- a/internal/infra/postgres/lesson_plan_repository.go
+++ b/internal/infra/postgres/lesson_plan_repository.go
@@ -10,69 +10,12 @@ import (
 	"github.com/misalima/edunex-backend/internal/core/domain_errors"
 	"github.com/misalima/edunex-backend/internal/core/interfaces/secondary"
 	"github.com/misalima/edunex-backend/internal/infra/logger"
+	"github.com/misalima/edunex-backend/internal/infra/postgres/models"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 )
 
 var _ secondary.LessonPlanLoader = (*LessonPlanRepository)(nil)
-
-type lessonPlanModel struct {
-	ID         uuid.UUID               `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
-	UserID     uuid.UUID               `gorm:"type:uuid;not null;index:idx_lesson_plans_user_id"`
-	Title      string                  `gorm:"type:text;not null"`
-	FilePath   string                  `gorm:"type:text;not null"`
-	RawContent *string                 `gorm:"type:text"`
-	Teacher    *string                 `gorm:"type:text"`
-	Discipline *string                 `gorm:"type:text"`
-	GradeLevel *domain.GradeLevel      `gorm:"type:varchar(50)"`
-	Status     domain.LessonPlanStatus `gorm:"type:lesson_plan_status;not null;default:'pending'"`
-	CreatedAt  time.Time               `gorm:"column:created_at;autoCreateTime"`
-}
-
-func (lessonPlanModel) TableName() string {
-	return "lesson_plans"
-}
-
-func (m *lessonPlanModel) toDomain() *domain.LessonPlan {
-	if m == nil {
-		return nil
-	}
-	return &domain.LessonPlan{
-		ID:         m.ID,
-		UserID:     m.UserID,
-		Title:      m.Title,
-		FilePath:   m.FilePath,
-		RawContent: m.RawContent,
-		GradeLevel: m.GradeLevel,
-		Teacher:    m.Teacher,
-		Discipline: m.Discipline,
-		Status:     m.Status,
-		CreatedAt:  m.CreatedAt,
-	}
-}
-
-func fromDomainLessonPlan(lp *domain.LessonPlan) *lessonPlanModel {
-	if lp == nil {
-		return nil
-	}
-	m := &lessonPlanModel{
-		UserID:     lp.UserID,
-		Title:      lp.Title,
-		FilePath:   lp.FilePath,
-		RawContent: lp.RawContent,
-		GradeLevel: lp.GradeLevel,
-		Teacher:    lp.Teacher,
-		Discipline: lp.Discipline,
-		Status:     lp.Status,
-	}
-	if lp.ID != uuid.Nil {
-		m.ID = lp.ID
-	}
-	if !lp.CreatedAt.IsZero() {
-		m.CreatedAt = lp.CreatedAt
-	}
-	return m
-}
 
 type LessonPlanRepository struct {
 	db *gorm.DB
@@ -83,7 +26,7 @@ func NewLessonPlanRepository(db *gorm.DB) *LessonPlanRepository {
 }
 
 func (r *LessonPlanRepository) InsertLessonPlan(ctx context.Context, lp *domain.LessonPlan) (uuid.UUID, error) {
-	m := fromDomainLessonPlan(lp)
+	m := models.FromDomainLessonPlan(lp)
 	if m.ID == uuid.Nil {
 		m.ID = uuid.New()
 	}
@@ -98,7 +41,7 @@ func (r *LessonPlanRepository) InsertLessonPlan(ctx context.Context, lp *domain.
 
 func (r *LessonPlanRepository) GetLessonPlanByID(ctx context.Context, id uuid.UUID) (*domain.LessonPlan, error) {
 	logger.Log.Debug("fetching lesson plan by id", zap.String("lesson_plan_id", id.String()))
-	m := &lessonPlanModel{}
+	m := &models.LessonPlanModel{}
 	if err := r.db.WithContext(ctx).First(m, "id = ?", id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			logger.Log.Info("lesson plan not found", zap.String("lesson_plan_id", id.String()))
@@ -108,20 +51,20 @@ func (r *LessonPlanRepository) GetLessonPlanByID(ctx context.Context, id uuid.UU
 		return nil, domain_errors.WrapUnexpectedMsg(err, "failed to fetch lesson plan")
 	}
 	logger.Log.Debug("lesson plan fetched", zap.String("lesson_plan_id", m.ID.String()), zap.String("user_id", m.UserID.String()))
-	return m.toDomain(), nil
+	return m.ToDomain(), nil
 }
 
 func (r *LessonPlanRepository) ListLessonPlans(ctx context.Context) ([]*domain.LessonPlan, error) {
 	logger.Log.Debug("listing lesson plans")
-	var models []lessonPlanModel
-	if err := r.db.WithContext(ctx).Order("created_at desc").Find(&models).Error; err != nil {
+	var dbModels []models.LessonPlanModel
+	if err := r.db.WithContext(ctx).Order("created_at desc").Find(&dbModels).Error; err != nil {
 		logger.Log.Error("failed to list lesson plans", zap.Error(err))
 		return nil, domain_errors.WrapUnexpectedMsg(err, "failed to list lesson plans")
 	}
-	logger.Log.Info("lesson plans listed", zap.Int("count", len(models)))
-	out := make([]*domain.LessonPlan, len(models))
-	for i := range models {
-		out[i] = models[i].toDomain()
+	logger.Log.Info("lesson plans listed", zap.Int("count", len(dbModels)))
+	out := make([]*domain.LessonPlan, len(dbModels))
+	for i := range dbModels {
+		out[i] = dbModels[i].ToDomain()
 	}
 	return out, nil
 }
@@ -130,7 +73,7 @@ func (r *LessonPlanRepository) UpdateLessonPlan(ctx context.Context, lp *domain.
 	if lp == nil || lp.ID == uuid.Nil {
 		return domain_errors.NewBadRequestMsg("lesson plan id is required")
 	}
-	m := fromDomainLessonPlan(lp)
+	m := models.FromDomainLessonPlan(lp)
 	logger.Log.Info("updating lesson plan", zap.String("lesson_plan_id", m.ID.String()))
 	updates := map[string]interface{}{
 		"updated_at": time.Now(),
@@ -144,7 +87,7 @@ func (r *LessonPlanRepository) UpdateLessonPlan(ctx context.Context, lp *domain.
 	if m.Status != "" {
 		updates["status"] = m.Status
 	}
-	res := r.db.WithContext(ctx).Model(&lessonPlanModel{}).Where("id = ?", m.ID).Updates(updates)
+	res := r.db.WithContext(ctx).Model(&models.LessonPlanModel{}).Where("id = ?", m.ID).Updates(updates)
 	if res.Error != nil {
 		logger.Log.Error("failed to update lesson plan", zap.Error(res.Error), zap.String("lesson_plan_id", m.ID.String()))
 		return domain_errors.WrapUnexpectedMsg(res.Error, "failed to update lesson plan")
@@ -156,3 +99,4 @@ func (r *LessonPlanRepository) UpdateLessonPlan(ctx context.Context, lp *domain.
 	logger.Log.Info("lesson plan updated", zap.String("lesson_plan_id", m.ID.String()), zap.Int64("rows_affected", res.RowsAffected))
 	return nil
 }
+

--- a/internal/infra/postgres/models/analysis_job.go
+++ b/internal/infra/postgres/models/analysis_job.go
@@ -1,0 +1,40 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/misalima/edunex-backend/internal/core/domain"
+)
+
+type AnalysisJobModel struct {
+	ID           uuid.UUID `gorm:"type:uuid;primaryKey"`
+	LessonPlanID uuid.UUID `gorm:"type:uuid;uniqueIndex"`
+	Status       string    `gorm:"index"`
+	Attempts     int
+	ErrorMessage string
+	CreatedAt    time.Time
+	StartedAt    *time.Time
+	FinishedAt   *time.Time
+}
+
+// TableName specifies the table name for GORM
+func (AnalysisJobModel) TableName() string {
+	return "analysis_jobs"
+}
+
+func (m *AnalysisJobModel) ToDomain() *domain.AnalysisJob {
+	if m == nil {
+		return nil
+	}
+	return &domain.AnalysisJob{
+		ID:           m.ID,
+		LessonPlanID: m.LessonPlanID,
+		Status:       m.Status,
+		Attempts:     m.Attempts,
+		ErrorMessage: m.ErrorMessage,
+		CreatedAt:    m.CreatedAt,
+		StartedAt:    m.StartedAt,
+		FinishedAt:   m.FinishedAt,
+	}
+}

--- a/internal/infra/postgres/models/lesson_plan.go
+++ b/internal/infra/postgres/models/lesson_plan.go
@@ -1,0 +1,66 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/misalima/edunex-backend/internal/core/domain"
+)
+
+type LessonPlanModel struct {
+	ID         uuid.UUID               `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
+	UserID     uuid.UUID               `gorm:"type:uuid;not null;index:idx_lesson_plans_user_id"`
+	Title      string                  `gorm:"type:text;not null"`
+	FilePath   string                  `gorm:"type:text;not null"`
+	RawContent *string                 `gorm:"type:text"`
+	Teacher    *string                 `gorm:"type:text"`
+	Discipline *string                 `gorm:"type:text"`
+	GradeLevel *domain.GradeLevel      `gorm:"type:varchar(50)"`
+	Status     domain.LessonPlanStatus `gorm:"type:lesson_plan_status;not null;default:'pending'"`
+	CreatedAt  time.Time               `gorm:"column:created_at;autoCreateTime"`
+}
+
+func (LessonPlanModel) TableName() string {
+	return "lesson_plans"
+}
+
+func (m *LessonPlanModel) ToDomain() *domain.LessonPlan {
+	if m == nil {
+		return nil
+	}
+	return &domain.LessonPlan{
+		ID:         m.ID,
+		UserID:     m.UserID,
+		Title:      m.Title,
+		FilePath:   m.FilePath,
+		RawContent: m.RawContent,
+		GradeLevel: m.GradeLevel,
+		Teacher:    m.Teacher,
+		Discipline: m.Discipline,
+		Status:     m.Status,
+		CreatedAt:  m.CreatedAt,
+	}
+}
+
+func FromDomainLessonPlan(lp *domain.LessonPlan) *LessonPlanModel {
+	if lp == nil {
+		return nil
+	}
+	m := &LessonPlanModel{
+		UserID:     lp.UserID,
+		Title:      lp.Title,
+		FilePath:   lp.FilePath,
+		RawContent: lp.RawContent,
+		GradeLevel: lp.GradeLevel,
+		Teacher:    lp.Teacher,
+		Discipline: lp.Discipline,
+		Status:     lp.Status,
+	}
+	if lp.ID != uuid.Nil {
+		m.ID = lp.ID
+	}
+	if !lp.CreatedAt.IsZero() {
+		m.CreatedAt = lp.CreatedAt
+	}
+	return m
+}

--- a/internal/infra/postgres/models/lesson_plan_analysis.go
+++ b/internal/infra/postgres/models/lesson_plan_analysis.go
@@ -1,0 +1,62 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/misalima/edunex-backend/internal/core/domain"
+	"gorm.io/datatypes"
+)
+
+type LessonPlanAnalysisModel struct {
+	ID             uuid.UUID      `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
+	LessonPlanID   uuid.UUID      `gorm:"type:uuid;not null;uniqueIndex:idx_lpa_lesson_plan_id"`
+	Title          string         `gorm:"type:text;not null"`
+	Subject        string         `gorm:"type:text;not null"`
+	GradeLevel     string         `gorm:"type:text;not null"`
+	AlignmentScore int            `gorm:"type:integer;not null;check:alignment_score >= 0 AND alignment_score <= 100"`
+	Feedback       string         `gorm:"type:text;not null"`
+	Metadata       datatypes.JSON `gorm:"type:jsonb;not null"`
+	Suggestions    datatypes.JSON `gorm:"type:jsonb;not null"`
+	CreatedAt      time.Time      `gorm:"column:created_at;autoCreateTime"`
+}
+
+func (LessonPlanAnalysisModel) TableName() string {
+	return "lesson_plan_analyses"
+}
+
+func (m *LessonPlanAnalysisModel) ToDomain() *domain.LessonPlanAnalysis {
+	if m == nil {
+		return nil
+	}
+	return &domain.LessonPlanAnalysis{
+		ID:             m.ID,
+		LessonPlanID:   m.LessonPlanID,
+		Title:          m.Title,
+		Subject:        m.Subject,
+		GradeLevel:     m.GradeLevel,
+		AlignmentScore: m.AlignmentScore,
+		Feedback:       m.Feedback,
+		Metadata:       string(m.Metadata),
+		Suggestions:    string(m.Suggestions),
+		CreatedAt:      m.CreatedAt,
+	}
+}
+
+func FromDomainAnalysis(lpa *domain.LessonPlanAnalysis) *LessonPlanAnalysisModel {
+	if lpa == nil {
+		return nil
+	}
+	return &LessonPlanAnalysisModel{
+		ID:             lpa.ID,
+		LessonPlanID:   lpa.LessonPlanID,
+		Title:          lpa.Title,
+		Subject:        lpa.Subject,
+		GradeLevel:     lpa.GradeLevel,
+		AlignmentScore: lpa.AlignmentScore,
+		Feedback:       lpa.Feedback,
+		Metadata:       datatypes.JSON(lpa.Metadata),
+		Suggestions:    datatypes.JSON(lpa.Suggestions),
+		CreatedAt:      lpa.CreatedAt,
+	}
+}

--- a/internal/infra/postgres/models/user.go
+++ b/internal/infra/postgres/models/user.go
@@ -1,0 +1,53 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/misalima/edunex-backend/internal/core/domain"
+)
+
+// UserModel maps to the users table and contains GORM tags.
+type UserModel struct {
+	ID        uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
+	Name      string    `gorm:"type:varchar(255);not null"`
+	Email     string    `gorm:"type:varchar(255);uniqueIndex;not null"`
+	Role      string    `gorm:"type:varchar(255);not null"`
+	CreatedAt time.Time `gorm:"column:created_at;autoCreateTime"`
+	UpdatedAt time.Time `gorm:"column:updated_at;autoUpdateTime"`
+}
+
+func (UserModel) TableName() string {
+	return "users"
+}
+
+// ToDomain converts UserModel to domain.User
+func (m *UserModel) ToDomain() *domain.User {
+	if m == nil {
+		return nil
+	}
+	return &domain.User{
+		ID:      m.ID,
+		Name:    m.Name,
+		Email:   m.Email,
+		Role:    m.Role,
+		Created: m.CreatedAt,
+		Updated: m.UpdatedAt,
+	}
+}
+
+// FromDomainUser creates a UserModel from domain.User. It does not overwrite ID when it's zero.
+func FromDomainUser(u *domain.User) *UserModel {
+	if u == nil {
+		return nil
+	}
+	m := &UserModel{
+		Name:  u.Name,
+		Email: u.Email,
+		Role:  u.Role,
+	}
+	if u.ID != uuid.Nil {
+		m.ID = u.ID
+	}
+	return m
+}

--- a/internal/infra/postgres/user_repository.go
+++ b/internal/infra/postgres/user_repository.go
@@ -9,54 +9,12 @@ import (
 	"github.com/misalima/edunex-backend/internal/core/domain"
 	"github.com/misalima/edunex-backend/internal/core/domain_errors"
 	"github.com/misalima/edunex-backend/internal/core/interfaces/secondary"
+	"github.com/misalima/edunex-backend/internal/infra/postgres/models"
 	"gorm.io/gorm"
 )
 
 // ensure UserRepository implements the UserLoader interface
 var _ secondary.UserLoader = (*UserRepository)(nil)
-
-// userModel maps to the users table and contains GORM tags.
-// We keep domain.User free of GORM tags per hexagonal architecture.
-type userModel struct {
-	ID        uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
-	Name      string    `gorm:"type:varchar(255);not null"`
-	Email     string    `gorm:"type:varchar(255);uniqueIndex;not null"`
-	Role      string    `gorm:"type:varchar(255);not null"`
-	CreatedAt time.Time `gorm:"column:created_at;autoCreateTime"`
-	UpdatedAt time.Time `gorm:"column:updated_at;autoUpdateTime"`
-}
-
-func (userModel) TableName() string {
-	return "users"
-}
-
-// toDomain converts userModel to domain.User
-func (m *userModel) toDomain() *domain.User {
-	if m == nil {
-		return nil
-	}
-	return &domain.User{
-		ID:      m.ID,
-		Name:    m.Name,
-		Email:   m.Email,
-		Role:    m.Role,
-		Created: m.CreatedAt,
-		Updated: m.UpdatedAt,
-	}
-}
-
-// fromDomain creates a userModel from domain.User. It does not overwrite ID when it's zero.
-func fromDomain(u *domain.User) *userModel {
-	m := &userModel{
-		Name:  u.Name,
-		Email: u.Email,
-		Role:  u.Role,
-	}
-	if u.ID != uuid.Nil {
-		m.ID = u.ID
-	}
-	return m
-}
 
 // UserRepository is the GORM implementation of UserLoader
 type UserRepository struct {
@@ -70,7 +28,7 @@ func NewGormUserRepository(db *gorm.DB) *UserRepository {
 
 // InsertUser inserts a user and returns the created id as string
 func (r *UserRepository) InsertUser(ctx context.Context, user *domain.User) (uuid.UUID, error) {
-	m := fromDomain(user)
+	m := models.FromDomainUser(user)
 	if m.ID == uuid.Nil {
 		m.ID = uuid.New()
 	}
@@ -82,31 +40,31 @@ func (r *UserRepository) InsertUser(ctx context.Context, user *domain.User) (uui
 
 // GetUserByID fetches a user by UUID
 func (r *UserRepository) GetUserByID(ctx context.Context, id uuid.UUID) (*domain.User, error) {
-	m := &userModel{}
+	m := &models.UserModel{}
 	if err := r.db.WithContext(ctx).First(m, "id = ?", id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, domain_errors.NewNotFoundMsg("user not found")
 		}
 		return nil, domain_errors.WrapUnexpectedMsg(err, "failed to fetch user")
 	}
-	return m.toDomain(), nil
+	return m.ToDomain(), nil
 }
 
 // GetUserByEmail fetches a user by email
 func (r *UserRepository) GetUserByEmail(ctx context.Context, email string) (*domain.User, error) {
-	m := &userModel{}
+	m := &models.UserModel{}
 	if err := r.db.WithContext(ctx).First(m, "email = ?", email).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, domain_errors.NewNotFoundMsg("user not found")
 		}
 		return nil, domain_errors.WrapUnexpectedMsg(err, "failed to fetch user")
 	}
-	return m.toDomain(), nil
+	return m.ToDomain(), nil
 }
 
 // UpdateUser updates mutable fields of a user
 func (r *UserRepository) UpdateUser(ctx context.Context, user *domain.User) error {
-	m := fromDomain(user)
+	m := models.FromDomainUser(user)
 	if m.ID == uuid.Nil {
 		return domain_errors.NewBadRequestMsg("user ID is required for update")
 	}
@@ -121,7 +79,7 @@ func (r *UserRepository) UpdateUser(ctx context.Context, user *domain.User) erro
 	if m.Email != "" {
 		updates["email"] = m.Email
 	}
-	if err := r.db.WithContext(ctx).Model(&userModel{}).Where("id = ?", m.ID).Updates(updates).Error; err != nil {
+	if err := r.db.WithContext(ctx).Model(&models.UserModel{}).Where("id = ?", m.ID).Updates(updates).Error; err != nil {
 		return domain_errors.WrapUnexpectedMsg(err, "failed to update user")
 	}
 	return nil
@@ -129,13 +87,13 @@ func (r *UserRepository) UpdateUser(ctx context.Context, user *domain.User) erro
 
 // ListUsers returns all users ordered by created_at
 func (r *UserRepository) ListUsers(ctx context.Context) ([]*domain.User, error) {
-	var models []userModel
-	if err := r.db.WithContext(ctx).Order("created_at desc").Find(&models).Error; err != nil {
+	var dbModels []models.UserModel
+	if err := r.db.WithContext(ctx).Order("created_at desc").Find(&dbModels).Error; err != nil {
 		return nil, domain_errors.WrapUnexpectedMsg(err, "failed to list users")
 	}
-	users := make([]*domain.User, len(models))
-	for i := range models {
-		users[i] = models[i].toDomain()
+	users := make([]*domain.User, len(dbModels))
+	for i := range dbModels {
+		users[i] = dbModels[i].ToDomain()
 	}
 	return users, nil
 }
@@ -143,7 +101,7 @@ func (r *UserRepository) ListUsers(ctx context.Context) ([]*domain.User, error) 
 func (r *UserRepository) UpdateRole(ctx context.Context, userID uuid.UUID, role string) error {
 
 	res := r.db.WithContext(ctx).
-		Model(&userModel{}).
+		Model(&models.UserModel{}).
 		Where("id = ?", userID).
 		Update("role", role)
 
@@ -157,3 +115,4 @@ func (r *UserRepository) UpdateRole(ctx context.Context, userID uuid.UUID, role 
 
 	return nil
 }
+


### PR DESCRIPTION
This pull request refactors the repository layer for lesson plans, analysis jobs, and lesson plan analyses by moving the GORM model definitions and domain conversion logic into a dedicated `models` package. This change improves code organization, maintainability, and separation of concerns by centralizing model-related code and conversion functions.

**Repository Model Refactoring and Codebase Simplification:**

* All GORM model structs and their domain conversion functions have been removed from repository files and are now imported from the new `internal/infra/postgres/models` package. This affects `lesson_plan_repository.go`, `analysis_job_repository.go`, and `lesson_plan_analysis_repository.go`. [[1]](diffhunk://#diff-c3653cffdd51247d7e092cfb225b7663c36bc3e6cbe16b34a33233bb3007b1e3L10-L45) [[2]](diffhunk://#diff-189ff8f2bc967b913ae0b9866ce2521e2856f2551894eab3296601ba466311ccL6-L72) [[3]](diffhunk://#diff-5b46a282c05cc91390d7fc4108343cf61ddc9e021ddb78d17d1fdf046c8af5cdR13-L76)

* All repository methods now use the corresponding model types and conversion functions from the `models` package, replacing previous inline model definitions and conversion logic. For example, calls to `toDomain()` and `fromDomain*` are replaced with `ToDomain()` and `FromDomain*`. [[1]](diffhunk://#diff-c3653cffdd51247d7e092cfb225b7663c36bc3e6cbe16b34a33233bb3007b1e3L80-R48) [[2]](diffhunk://#diff-c3653cffdd51247d7e092cfb225b7663c36bc3e6cbe16b34a33233bb3007b1e3L95-R63) [[3]](diffhunk://#diff-c3653cffdd51247d7e092cfb225b7663c36bc3e6cbe16b34a33233bb3007b1e3L135-R109) [[4]](diffhunk://#diff-c3653cffdd51247d7e092cfb225b7663c36bc3e6cbe16b34a33233bb3007b1e3L179-R153) [[5]](diffhunk://#diff-c3653cffdd51247d7e092cfb225b7663c36bc3e6cbe16b34a33233bb3007b1e3L202-R170) [[6]](diffhunk://#diff-c3653cffdd51247d7e092cfb225b7663c36bc3e6cbe16b34a33233bb3007b1e3L237-R205) [[7]](diffhunk://#diff-c3653cffdd51247d7e092cfb225b7663c36bc3e6cbe16b34a33233bb3007b1e3L248-R224) [[8]](diffhunk://#diff-c3653cffdd51247d7e092cfb225b7663c36bc3e6cbe16b34a33233bb3007b1e3L278-R247) [[9]](diffhunk://#diff-c3653cffdd51247d7e092cfb225b7663c36bc3e6cbe16b34a33233bb3007b1e3L305-R280) [[10]](diffhunk://#diff-c3653cffdd51247d7e092cfb225b7663c36bc3e6cbe16b34a33233bb3007b1e3L329-R290) [[11]](diffhunk://#diff-c3653cffdd51247d7e092cfb225b7663c36bc3e6cbe16b34a33233bb3007b1e3L347-R308) [[12]](diffhunk://#diff-c3653cffdd51247d7e092cfb225b7663c36bc3e6cbe16b34a33233bb3007b1e3L358-R321) [[13]](diffhunk://#diff-189ff8f2bc967b913ae0b9866ce2521e2856f2551894eab3296601ba466311ccL89-R35) [[14]](diffhunk://#diff-189ff8f2bc967b913ae0b9866ce2521e2856f2551894eab3296601ba466311ccL121-R67) [[15]](diffhunk://#diff-189ff8f2bc967b913ae0b9866ce2521e2856f2551894eab3296601ba466311ccL137-R85) [[16]](diffhunk://#diff-5b46a282c05cc91390d7fc4108343cf61ddc9e021ddb78d17d1fdf046c8af5cdL86-R29) [[17]](diffhunk://#diff-5b46a282c05cc91390d7fc4108343cf61ddc9e021ddb78d17d1fdf046c8af5cdL101-R44) [[18]](diffhunk://#diff-5b46a282c05cc91390d7fc4108343cf61ddc9e021ddb78d17d1fdf046c8af5cdL111-R67) [[19]](diffhunk://#diff-5b46a282c05cc91390d7fc4108343cf61ddc9e021ddb78d17d1fdf046c8af5cdL133-R76) [[20]](diffhunk://#diff-5b46a282c05cc91390d7fc4108343cf61ddc9e021ddb78d17d1fdf046c8af5cdL147-R90)

* All GORM queries and updates now reference model types from the `models` package, ensuring consistency and reducing duplication across the codebase. [[1]](diffhunk://#diff-c3653cffdd51247d7e092cfb225b7663c36bc3e6cbe16b34a33233bb3007b1e3L329-R290) [[2]](diffhunk://#diff-c3653cffdd51247d7e092cfb225b7663c36bc3e6cbe16b34a33233bb3007b1e3L278-R247) [[3]](diffhunk://#diff-c3653cffdd51247d7e092cfb225b7663c36bc3e6cbe16b34a33233bb3007b1e3L248-R224) [[4]](diffhunk://#diff-5b46a282c05cc91390d7fc4108343cf61ddc9e021ddb78d17d1fdf046c8af5cdL147-R90)

This refactor centralizes model management, making the repository layer cleaner and easier to maintain.