### PR TITLE
Pagination and Deletion of Lesson Plans

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test test-cover lint build clean mockgen
+.PHONY: help test test-cover lint build run clean mockgen
 
 help:
 	@echo "Available targets:"
@@ -6,6 +6,7 @@ help:
 	@echo "  test-cover  - Run tests with coverage report"
 	@echo "  lint        - Run golangci-lint"
 	@echo "  build       - Build the project"
+	@echo "  run         - Run the API locally (loads .env from project root)"
 	@echo "  clean       - Remove temporary files"
 	@echo "  mockgen     - Regenerate mocks"
 
@@ -24,9 +25,12 @@ lint:
 build:
 	go build ./...
 
+run:
+	go run ./cmd/app
+
 clean:
 	rm -f coverage.out coverage.html
 
 mockgen:
-	mockgen -source=internal/core/interfaces/iservice/lesson_plan_manager.go -destination=internal/api/handlers/mocks/mock_lesson_plan_manager.go -package=mocks
-	mockgen -source=internal/core/interfaces/iservice/user_manager.go -destination=internal/api/handlers/mocks/mock_user_manager.go -package=mocks
+	mockgen -source=internal/core/interfaces/primary/lesson_plan_manager.go -destination=internal/api/handlers/mocks/mock_lesson_plan_manager.go -package=mocks
+	mockgen -source=internal/core/interfaces/primary/user_manager.go -destination=internal/api/handlers/mocks/mock_user_manager.go -package=mocks

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -49,7 +49,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/request.UpdateRoleRequest"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_request.UpdateRoleRequest"
                         }
                     }
                 ],
@@ -57,31 +57,126 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.MessageResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.MessageResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorMessageResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/analysis-jobs/metrics": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns job processing metrics and statistics",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Analysis"
+                ],
+                "summary": "Get job metrics",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.JobMetricsResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/analysis-jobs/{job_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the status of an analysis job",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Analysis"
+                ],
+                "summary": "Get analysis job status",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Job ID",
+                        "name": "job_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.AnalysisJobResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     }
                 }
@@ -101,7 +196,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.HealthResponse"
+                            "$ref": "#/definitions/internal_api_handlers.HealthResponse"
                         }
                     }
                 }
@@ -114,7 +209,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns all lesson plans with signed download URLs when available.",
+                "description": "Returns lesson plans for the authenticated user with pagination and signed URLs.",
                 "produces": [
                     "application/json"
                 ],
@@ -122,26 +217,37 @@ const docTemplate = `{
                     "Lesson Plans"
                 ],
                 "summary": "List lesson plans",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Max items per page (1-100, default 20)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Number of items to skip (default 0)",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/response.LessonPlanResponse"
-                            }
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.PaginatedLessonPlanResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     }
                 }
@@ -201,25 +307,25 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/response.LessonPlanResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.LessonPlanResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorMessageResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     }
                 }
@@ -253,31 +359,200 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.LessonPlanResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.LessonPlanResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorMessageResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Deletes a lesson plan, its file, and associated analyses.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Lesson Plans"
+                ],
+                "summary": "Delete a lesson plan",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Lesson plan ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/lesson-plans/{id}/analysis": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the status and structured pedagogical analysis when ready.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Lesson Plans"
+                ],
+                "summary": "Get pedagogical analysis for a lesson plan",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Lesson plan ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.LessonPlanAnalysisStatusResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/lesson-plans/{lesson_plan_id}/analyze": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Enqueues a lesson plan for AI analysis processing in background",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Analysis"
+                ],
+                "summary": "Analyze lesson plan",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Lesson plan ID",
+                        "name": "lesson_plan_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.EnqueueAnalysisResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     }
                 }
@@ -290,7 +565,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns the authenticated user's profile, creating it from Supabase data when needed.",
+                "description": "Returns the authenticated user's profile.",
                 "produces": [
                     "application/json"
                 ],
@@ -302,19 +577,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.UserResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.UserResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     }
                 }
@@ -341,20 +622,20 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/response.UserResponse"
+                                "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.UserResponse"
                             }
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     }
                 }
@@ -388,31 +669,31 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.UserResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.UserResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorMessageResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     }
                 }
@@ -448,7 +729,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/request.UpdateUserRequest"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_request.UpdateUserRequest"
                         }
                     }
                 ],
@@ -462,25 +743,25 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorMessageResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     }
                 }
@@ -488,20 +769,7 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "handlers.HealthResponse": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string",
-                    "example": "API is running correctly!"
-                },
-                "status": {
-                    "type": "string",
-                    "example": "ok"
-                }
-            }
-        },
-        "request.UpdateRoleRequest": {
+        "github_com_misalima_edunex-backend_internal_api_handlers_dto_request.UpdateRoleRequest": {
             "type": "object",
             "required": [
                 "role",
@@ -518,7 +786,7 @@ const docTemplate = `{
                 }
             }
         },
-        "request.UpdateUserRequest": {
+        "github_com_misalima_edunex-backend_internal_api_handlers_dto_request.UpdateUserRequest": {
             "type": "object",
             "properties": {
                 "name": {
@@ -527,7 +795,61 @@ const docTemplate = `{
                 }
             }
         },
-        "response.ErrorMessageResponse": {
+        "github_com_misalima_edunex-backend_internal_api_handlers_dto_response.AnalysisJobResponse": {
+            "type": "object",
+            "properties": {
+                "attempts": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "created_at": {
+                    "type": "string",
+                    "example": "2026-05-16T15:30:00Z"
+                },
+                "error_message": {
+                    "type": "string",
+                    "example": "API timeout"
+                },
+                "finished_at": {
+                    "type": "string",
+                    "example": "2026-05-16T15:30:05Z"
+                },
+                "job_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "lesson_plan_id": {
+                    "type": "string",
+                    "example": "11111111-1111-1111-1111-111111111111"
+                },
+                "started_at": {
+                    "type": "string",
+                    "example": "2026-05-16T15:30:01Z"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "processing"
+                }
+            }
+        },
+        "github_com_misalima_edunex-backend_internal_api_handlers_dto_response.EnqueueAnalysisResponse": {
+            "type": "object",
+            "properties": {
+                "job_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "lesson_plan_id": {
+                    "type": "string",
+                    "example": "11111111-1111-1111-1111-111111111111"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "pending"
+                }
+            }
+        },
+        "github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse": {
             "type": "object",
             "properties": {
                 "error": {
@@ -536,7 +858,7 @@ const docTemplate = `{
                 }
             }
         },
-        "response.ErrorResponse": {
+        "github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse": {
             "type": "object",
             "properties": {
                 "code": {
@@ -549,7 +871,100 @@ const docTemplate = `{
                 }
             }
         },
-        "response.LessonPlanResponse": {
+        "github_com_misalima_edunex-backend_internal_api_handlers_dto_response.JobMetricsResponse": {
+            "type": "object",
+            "properties": {
+                "active_workers": {
+                    "type": "integer",
+                    "example": 4
+                },
+                "db_stats": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                },
+                "failed_jobs": {
+                    "type": "integer",
+                    "example": 2
+                },
+                "processed_jobs": {
+                    "type": "integer",
+                    "example": 42
+                },
+                "retried_jobs": {
+                    "type": "integer",
+                    "example": 3
+                },
+                "successful_jobs": {
+                    "type": "integer",
+                    "example": 40
+                }
+            }
+        },
+        "github_com_misalima_edunex-backend_internal_api_handlers_dto_response.LessonPlanAnalysisResponse": {
+            "type": "object",
+            "properties": {
+                "alignment_score": {
+                    "type": "integer",
+                    "example": 85
+                },
+                "created_at": {
+                    "type": "string",
+                    "example": "2026-05-16T15:30:00Z"
+                },
+                "feedback": {
+                    "type": "string",
+                    "example": "O plano está bem estruturado..."
+                },
+                "grade_level": {
+                    "type": "string",
+                    "example": "1ª SÉRIE"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "lesson_plan_id": {
+                    "type": "string",
+                    "example": "11111111-1111-1111-1111-111111111111"
+                },
+                "metadata": {
+                    "type": "string",
+                    "example": "{\"objectives\": [\"Utilizar números inteiros\"]}"
+                },
+                "subject": {
+                    "type": "string",
+                    "example": "Matemática"
+                },
+                "suggestions": {
+                    "type": "string",
+                    "example": "[\"Adicionar atividades práticas\"]"
+                },
+                "title": {
+                    "type": "string",
+                    "example": "Plano de aula de Matemática"
+                }
+            }
+        },
+        "github_com_misalima_edunex-backend_internal_api_handlers_dto_response.LessonPlanAnalysisStatusResponse": {
+            "type": "object",
+            "properties": {
+                "analysis": {
+                    "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.LessonPlanAnalysisResponse"
+                },
+                "error_message": {
+                    "type": "string",
+                    "example": ""
+                },
+                "status": {
+                    "type": "string",
+                    "example": "done"
+                }
+            }
+        },
+        "github_com_misalima_edunex-backend_internal_api_handlers_dto_response.LessonPlanResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -590,7 +1005,7 @@ const docTemplate = `{
                 }
             }
         },
-        "response.MessageResponse": {
+        "github_com_misalima_edunex-backend_internal_api_handlers_dto_response.MessageResponse": {
             "type": "object",
             "properties": {
                 "message": {
@@ -599,7 +1014,30 @@ const docTemplate = `{
                 }
             }
         },
-        "response.UserResponse": {
+        "github_com_misalima_edunex-backend_internal_api_handlers_dto_response.PaginatedLessonPlanResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.LessonPlanResponse"
+                    }
+                },
+                "limit": {
+                    "type": "integer",
+                    "example": 20
+                },
+                "offset": {
+                    "type": "integer",
+                    "example": 0
+                },
+                "total": {
+                    "type": "integer",
+                    "example": 47
+                }
+            }
+        },
+        "github_com_misalima_edunex-backend_internal_api_handlers_dto_response.UserResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -625,6 +1063,19 @@ const docTemplate = `{
                 "updated_at": {
                     "type": "string",
                     "example": "2026-05-16T15:30:00Z"
+                }
+            }
+        },
+        "internal_api_handlers.HealthResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "example": "API is running correctly!"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "ok"
                 }
             }
         }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -47,7 +47,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/request.UpdateRoleRequest"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_request.UpdateRoleRequest"
                         }
                     }
                 ],
@@ -55,31 +55,126 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.MessageResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.MessageResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorMessageResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/analysis-jobs/metrics": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns job processing metrics and statistics",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Analysis"
+                ],
+                "summary": "Get job metrics",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.JobMetricsResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/analysis-jobs/{job_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the status of an analysis job",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Analysis"
+                ],
+                "summary": "Get analysis job status",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Job ID",
+                        "name": "job_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.AnalysisJobResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     }
                 }
@@ -99,7 +194,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/handlers.HealthResponse"
+                            "$ref": "#/definitions/internal_api_handlers.HealthResponse"
                         }
                     }
                 }
@@ -112,7 +207,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns all lesson plans with signed download URLs when available.",
+                "description": "Returns lesson plans for the authenticated user with pagination and signed URLs.",
                 "produces": [
                     "application/json"
                 ],
@@ -120,26 +215,37 @@
                     "Lesson Plans"
                 ],
                 "summary": "List lesson plans",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Max items per page (1-100, default 20)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Number of items to skip (default 0)",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/response.LessonPlanResponse"
-                            }
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.PaginatedLessonPlanResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     }
                 }
@@ -199,25 +305,25 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/response.LessonPlanResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.LessonPlanResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorMessageResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     }
                 }
@@ -251,31 +357,200 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.LessonPlanResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.LessonPlanResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorMessageResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Deletes a lesson plan, its file, and associated analyses.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Lesson Plans"
+                ],
+                "summary": "Delete a lesson plan",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Lesson plan ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/lesson-plans/{id}/analysis": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the status and structured pedagogical analysis when ready.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Lesson Plans"
+                ],
+                "summary": "Get pedagogical analysis for a lesson plan",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Lesson plan ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.LessonPlanAnalysisStatusResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/lesson-plans/{lesson_plan_id}/analyze": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Enqueues a lesson plan for AI analysis processing in background",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Analysis"
+                ],
+                "summary": "Analyze lesson plan",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Lesson plan ID",
+                        "name": "lesson_plan_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.EnqueueAnalysisResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     }
                 }
@@ -288,7 +563,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns the authenticated user's profile, creating it from Supabase data when needed.",
+                "description": "Returns the authenticated user's profile.",
                 "produces": [
                     "application/json"
                 ],
@@ -300,19 +575,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.UserResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.UserResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     }
                 }
@@ -339,20 +620,20 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/response.UserResponse"
+                                "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.UserResponse"
                             }
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     }
                 }
@@ -386,31 +667,31 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.UserResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.UserResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorMessageResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     }
                 }
@@ -446,7 +727,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/request.UpdateUserRequest"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_request.UpdateUserRequest"
                         }
                     }
                 ],
@@ -460,25 +741,25 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorMessageResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.ErrorResponse"
+                            "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse"
                         }
                     }
                 }
@@ -486,20 +767,7 @@
         }
     },
     "definitions": {
-        "handlers.HealthResponse": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string",
-                    "example": "API is running correctly!"
-                },
-                "status": {
-                    "type": "string",
-                    "example": "ok"
-                }
-            }
-        },
-        "request.UpdateRoleRequest": {
+        "github_com_misalima_edunex-backend_internal_api_handlers_dto_request.UpdateRoleRequest": {
             "type": "object",
             "required": [
                 "role",
@@ -516,7 +784,7 @@
                 }
             }
         },
-        "request.UpdateUserRequest": {
+        "github_com_misalima_edunex-backend_internal_api_handlers_dto_request.UpdateUserRequest": {
             "type": "object",
             "properties": {
                 "name": {
@@ -525,7 +793,61 @@
                 }
             }
         },
-        "response.ErrorMessageResponse": {
+        "github_com_misalima_edunex-backend_internal_api_handlers_dto_response.AnalysisJobResponse": {
+            "type": "object",
+            "properties": {
+                "attempts": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "created_at": {
+                    "type": "string",
+                    "example": "2026-05-16T15:30:00Z"
+                },
+                "error_message": {
+                    "type": "string",
+                    "example": "API timeout"
+                },
+                "finished_at": {
+                    "type": "string",
+                    "example": "2026-05-16T15:30:05Z"
+                },
+                "job_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "lesson_plan_id": {
+                    "type": "string",
+                    "example": "11111111-1111-1111-1111-111111111111"
+                },
+                "started_at": {
+                    "type": "string",
+                    "example": "2026-05-16T15:30:01Z"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "processing"
+                }
+            }
+        },
+        "github_com_misalima_edunex-backend_internal_api_handlers_dto_response.EnqueueAnalysisResponse": {
+            "type": "object",
+            "properties": {
+                "job_id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "lesson_plan_id": {
+                    "type": "string",
+                    "example": "11111111-1111-1111-1111-111111111111"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "pending"
+                }
+            }
+        },
+        "github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse": {
             "type": "object",
             "properties": {
                 "error": {
@@ -534,7 +856,7 @@
                 }
             }
         },
-        "response.ErrorResponse": {
+        "github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse": {
             "type": "object",
             "properties": {
                 "code": {
@@ -547,7 +869,100 @@
                 }
             }
         },
-        "response.LessonPlanResponse": {
+        "github_com_misalima_edunex-backend_internal_api_handlers_dto_response.JobMetricsResponse": {
+            "type": "object",
+            "properties": {
+                "active_workers": {
+                    "type": "integer",
+                    "example": 4
+                },
+                "db_stats": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                },
+                "failed_jobs": {
+                    "type": "integer",
+                    "example": 2
+                },
+                "processed_jobs": {
+                    "type": "integer",
+                    "example": 42
+                },
+                "retried_jobs": {
+                    "type": "integer",
+                    "example": 3
+                },
+                "successful_jobs": {
+                    "type": "integer",
+                    "example": 40
+                }
+            }
+        },
+        "github_com_misalima_edunex-backend_internal_api_handlers_dto_response.LessonPlanAnalysisResponse": {
+            "type": "object",
+            "properties": {
+                "alignment_score": {
+                    "type": "integer",
+                    "example": 85
+                },
+                "created_at": {
+                    "type": "string",
+                    "example": "2026-05-16T15:30:00Z"
+                },
+                "feedback": {
+                    "type": "string",
+                    "example": "O plano está bem estruturado..."
+                },
+                "grade_level": {
+                    "type": "string",
+                    "example": "1ª SÉRIE"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "lesson_plan_id": {
+                    "type": "string",
+                    "example": "11111111-1111-1111-1111-111111111111"
+                },
+                "metadata": {
+                    "type": "string",
+                    "example": "{\"objectives\": [\"Utilizar números inteiros\"]}"
+                },
+                "subject": {
+                    "type": "string",
+                    "example": "Matemática"
+                },
+                "suggestions": {
+                    "type": "string",
+                    "example": "[\"Adicionar atividades práticas\"]"
+                },
+                "title": {
+                    "type": "string",
+                    "example": "Plano de aula de Matemática"
+                }
+            }
+        },
+        "github_com_misalima_edunex-backend_internal_api_handlers_dto_response.LessonPlanAnalysisStatusResponse": {
+            "type": "object",
+            "properties": {
+                "analysis": {
+                    "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.LessonPlanAnalysisResponse"
+                },
+                "error_message": {
+                    "type": "string",
+                    "example": ""
+                },
+                "status": {
+                    "type": "string",
+                    "example": "done"
+                }
+            }
+        },
+        "github_com_misalima_edunex-backend_internal_api_handlers_dto_response.LessonPlanResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -588,7 +1003,7 @@
                 }
             }
         },
-        "response.MessageResponse": {
+        "github_com_misalima_edunex-backend_internal_api_handlers_dto_response.MessageResponse": {
             "type": "object",
             "properties": {
                 "message": {
@@ -597,7 +1012,30 @@
                 }
             }
         },
-        "response.UserResponse": {
+        "github_com_misalima_edunex-backend_internal_api_handlers_dto_response.PaginatedLessonPlanResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.LessonPlanResponse"
+                    }
+                },
+                "limit": {
+                    "type": "integer",
+                    "example": 20
+                },
+                "offset": {
+                    "type": "integer",
+                    "example": 0
+                },
+                "total": {
+                    "type": "integer",
+                    "example": 47
+                }
+            }
+        },
+        "github_com_misalima_edunex-backend_internal_api_handlers_dto_response.UserResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -623,6 +1061,19 @@
                 "updated_at": {
                     "type": "string",
                     "example": "2026-05-16T15:30:00Z"
+                }
+            }
+        },
+        "internal_api_handlers.HealthResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "example": "API is running correctly!"
+                },
+                "status": {
+                    "type": "string",
+                    "example": "ok"
                 }
             }
         }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,15 +1,6 @@
 basePath: /api/v1
 definitions:
-  handlers.HealthResponse:
-    properties:
-      message:
-        example: API is running correctly!
-        type: string
-      status:
-        example: ok
-        type: string
-    type: object
-  request.UpdateRoleRequest:
+  github_com_misalima_edunex-backend_internal_api_handlers_dto_request.UpdateRoleRequest:
     properties:
       role:
         example: teacher
@@ -21,19 +12,58 @@ definitions:
     - role
     - user_id
     type: object
-  request.UpdateUserRequest:
+  github_com_misalima_edunex-backend_internal_api_handlers_dto_request.UpdateUserRequest:
     properties:
       name:
         example: Maria Silva
         type: string
     type: object
-  response.ErrorMessageResponse:
+  github_com_misalima_edunex-backend_internal_api_handlers_dto_response.AnalysisJobResponse:
+    properties:
+      attempts:
+        example: 1
+        type: integer
+      created_at:
+        example: "2026-05-16T15:30:00Z"
+        type: string
+      error_message:
+        example: API timeout
+        type: string
+      finished_at:
+        example: "2026-05-16T15:30:05Z"
+        type: string
+      job_id:
+        example: 550e8400-e29b-41d4-a716-446655440000
+        type: string
+      lesson_plan_id:
+        example: 11111111-1111-1111-1111-111111111111
+        type: string
+      started_at:
+        example: "2026-05-16T15:30:01Z"
+        type: string
+      status:
+        example: processing
+        type: string
+    type: object
+  github_com_misalima_edunex-backend_internal_api_handlers_dto_response.EnqueueAnalysisResponse:
+    properties:
+      job_id:
+        example: 550e8400-e29b-41d4-a716-446655440000
+        type: string
+      lesson_plan_id:
+        example: 11111111-1111-1111-1111-111111111111
+        type: string
+      status:
+        example: pending
+        type: string
+    type: object
+  github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse:
     properties:
       error:
         example: invalid request payload
         type: string
     type: object
-  response.ErrorResponse:
+  github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse:
     properties:
       code:
         example: NOT_FOUND
@@ -42,7 +72,74 @@ definitions:
         example: user not found
         type: string
     type: object
-  response.LessonPlanResponse:
+  github_com_misalima_edunex-backend_internal_api_handlers_dto_response.JobMetricsResponse:
+    properties:
+      active_workers:
+        example: 4
+        type: integer
+      db_stats:
+        additionalProperties:
+          format: int64
+          type: integer
+        type: object
+      failed_jobs:
+        example: 2
+        type: integer
+      processed_jobs:
+        example: 42
+        type: integer
+      retried_jobs:
+        example: 3
+        type: integer
+      successful_jobs:
+        example: 40
+        type: integer
+    type: object
+  github_com_misalima_edunex-backend_internal_api_handlers_dto_response.LessonPlanAnalysisResponse:
+    properties:
+      alignment_score:
+        example: 85
+        type: integer
+      created_at:
+        example: "2026-05-16T15:30:00Z"
+        type: string
+      feedback:
+        example: O plano está bem estruturado...
+        type: string
+      grade_level:
+        example: 1ª SÉRIE
+        type: string
+      id:
+        example: 550e8400-e29b-41d4-a716-446655440000
+        type: string
+      lesson_plan_id:
+        example: 11111111-1111-1111-1111-111111111111
+        type: string
+      metadata:
+        example: '{"objectives": ["Utilizar números inteiros"]}'
+        type: string
+      subject:
+        example: Matemática
+        type: string
+      suggestions:
+        example: '["Adicionar atividades práticas"]'
+        type: string
+      title:
+        example: Plano de aula de Matemática
+        type: string
+    type: object
+  github_com_misalima_edunex-backend_internal_api_handlers_dto_response.LessonPlanAnalysisStatusResponse:
+    properties:
+      analysis:
+        $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.LessonPlanAnalysisResponse'
+      error_message:
+        example: ""
+        type: string
+      status:
+        example: done
+        type: string
+    type: object
+  github_com_misalima_edunex-backend_internal_api_handlers_dto_response.LessonPlanResponse:
     properties:
       created_at:
         example: "2026-05-16T15:30:00Z"
@@ -72,13 +169,29 @@ definitions:
         example: 11111111-1111-1111-1111-111111111111
         type: string
     type: object
-  response.MessageResponse:
+  github_com_misalima_edunex-backend_internal_api_handlers_dto_response.MessageResponse:
     properties:
       message:
         example: user role updated successfully
         type: string
     type: object
-  response.UserResponse:
+  github_com_misalima_edunex-backend_internal_api_handlers_dto_response.PaginatedLessonPlanResponse:
+    properties:
+      items:
+        items:
+          $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.LessonPlanResponse'
+        type: array
+      limit:
+        example: 20
+        type: integer
+      offset:
+        example: 0
+        type: integer
+      total:
+        example: 47
+        type: integer
+    type: object
+  github_com_misalima_edunex-backend_internal_api_handlers_dto_response.UserResponse:
     properties:
       created_at:
         example: "2026-05-16T15:30:00Z"
@@ -97,6 +210,15 @@ definitions:
         type: string
       updated_at:
         example: "2026-05-16T15:30:00Z"
+        type: string
+    type: object
+  internal_api_handlers.HealthResponse:
+    properties:
+      message:
+        example: API is running correctly!
+        type: string
+      status:
+        example: ok
         type: string
     type: object
 host: localhost:8080
@@ -124,35 +246,95 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/request.UpdateRoleRequest'
+          $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_request.UpdateRoleRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/response.MessageResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.MessageResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/response.ErrorMessageResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.ErrorResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/response.ErrorResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.ErrorResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Update user role
       tags:
       - Admin
+  /analysis-jobs/{job_id}:
+    get:
+      description: Returns the status of an analysis job
+      parameters:
+      - description: Job ID
+        in: path
+        name: job_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.AnalysisJobResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get analysis job status
+      tags:
+      - Analysis
+  /analysis-jobs/metrics:
+    get:
+      description: Returns job processing metrics and statistics
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.JobMetricsResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get job metrics
+      tags:
+      - Analysis
   /health:
     get:
       description: Returns the API status.
@@ -162,30 +344,38 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/handlers.HealthResponse'
+            $ref: '#/definitions/internal_api_handlers.HealthResponse'
       summary: Health check
       tags:
       - Health
   /lesson-plans:
     get:
-      description: Returns all lesson plans with signed download URLs when available.
+      description: Returns lesson plans for the authenticated user with pagination
+        and signed URLs.
+      parameters:
+      - description: Max items per page (1-100, default 20)
+        in: query
+        name: limit
+        type: integer
+      - description: Number of items to skip (default 0)
+        in: query
+        name: offset
+        type: integer
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            items:
-              $ref: '#/definitions/response.LessonPlanResponse'
-            type: array
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.PaginatedLessonPlanResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.ErrorResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.ErrorResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
       security:
       - BearerAuth: []
       summary: List lesson plans
@@ -224,25 +414,59 @@ paths:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/response.LessonPlanResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.LessonPlanResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/response.ErrorMessageResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.ErrorResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.ErrorResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Create lesson plan
       tags:
       - Lesson Plans
   /lesson-plans/{id}:
+    delete:
+      description: Deletes a lesson plan, its file, and associated analyses.
+      parameters:
+      - description: Lesson plan ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Delete a lesson plan
+      tags:
+      - Lesson Plans
     get:
       description: Returns a lesson plan and a signed download URL.
       parameters:
@@ -257,47 +481,124 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/response.LessonPlanResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.LessonPlanResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/response.ErrorMessageResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.ErrorResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/response.ErrorResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.ErrorResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Get lesson plan by ID
       tags:
       - Lesson Plans
-  /me:
+  /lesson-plans/{id}/analysis:
     get:
-      description: Returns the authenticated user's profile, creating it from Supabase
-        data when needed.
+      description: Returns the status and structured pedagogical analysis when ready.
+      parameters:
+      - description: Lesson plan ID
+        in: path
+        name: id
+        required: true
+        type: string
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/response.UserResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.LessonPlanAnalysisStatusResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.ErrorResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.ErrorResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get pedagogical analysis for a lesson plan
+      tags:
+      - Lesson Plans
+  /lesson-plans/{lesson_plan_id}/analyze:
+    post:
+      description: Enqueues a lesson plan for AI analysis processing in background
+      parameters:
+      - description: Lesson plan ID
+        in: path
+        name: lesson_plan_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.EnqueueAnalysisResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Analyze lesson plan
+      tags:
+      - Analysis
+  /me:
+    get:
+      description: Returns the authenticated user's profile.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.UserResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Get current authenticated user
@@ -313,16 +614,16 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/response.UserResponse'
+              $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.UserResponse'
             type: array
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.ErrorResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.ErrorResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
       security:
       - BearerAuth: []
       summary: List users
@@ -343,23 +644,23 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/response.UserResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.UserResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/response.ErrorMessageResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.ErrorResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/response.ErrorResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.ErrorResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Get user by ID
@@ -380,7 +681,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/request.UpdateUserRequest'
+          $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_request.UpdateUserRequest'
       produces:
       - application/json
       responses:
@@ -391,19 +692,19 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/response.ErrorMessageResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorMessageResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.ErrorResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/response.ErrorResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.ErrorResponse'
+            $ref: '#/definitions/github_com_misalima_edunex-backend_internal_api_handlers_dto_response.ErrorResponse'
       security:
       - BearerAuth: []
       summary: Update user

--- a/internal/api/handlers/dto/response/lesson_plan.go
+++ b/internal/api/handlers/dto/response/lesson_plan.go
@@ -18,6 +18,13 @@ type LessonPlanResponse struct {
 	DownloadURL string    `json:"download_url,omitempty" example:"https://storage.example.com/signed-url"`
 }
 
+type PaginatedLessonPlanResponse struct {
+	Items  []*LessonPlanResponse `json:"items"`
+	Total  int64                 `json:"total" example:"47"`
+	Limit  int                   `json:"limit" example:"20"`
+	Offset int                   `json:"offset" example:"0"`
+}
+
 func FromDomainLessonPlanToResponse(lp *domain.LessonPlan) *LessonPlanResponse {
 	if lp == nil {
 		return nil

--- a/internal/api/handlers/lesson_plan_handler.go
+++ b/internal/api/handlers/lesson_plan_handler.go
@@ -3,12 +3,14 @@ package handlers
 import (
 	"net/http"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/misalima/edunex-backend/internal/api/handlers/dto/request"
 	"github.com/misalima/edunex-backend/internal/api/handlers/dto/response"
+	"github.com/misalima/edunex-backend/internal/core/domain"
 	"github.com/misalima/edunex-backend/internal/core/interfaces/primary"
 	"github.com/misalima/edunex-backend/internal/infra/logger"
 	"go.uber.org/zap"
@@ -92,23 +94,50 @@ func (h *LessonPlanHandler) Create(c echo.Context) error {
 
 // List godoc
 // @Summary List lesson plans
-// @Description Returns all lesson plans with signed download URLs when available.
+// @Description Returns lesson plans for the authenticated user with pagination and signed URLs.
 // @Tags Lesson Plans
 // @Produce json
 // @Security BearerAuth
-// @Success 200 {array} response.LessonPlanResponse
+// @Param limit query int false "Max items per page (1-100, default 20)"
+// @Param offset query int false "Number of items to skip (default 0)"
+// @Success 200 {object} response.PaginatedLessonPlanResponse
 // @Failure 401 {object} response.ErrorResponse
 // @Failure 500 {object} response.ErrorResponse
 // @Router /lesson-plans [get]
 func (h *LessonPlanHandler) List(c echo.Context) error {
 	ctx := c.Request().Context()
 
-	lps, urls, err := h.lessonPlanService.ListLessonPlansWithSignedURLs(ctx)
+	userID, err := getUserIDFromContext(c)
+	if err != nil {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+	}
+
+	limit := 20
+	offset := 0
+	if v := c.QueryParam("limit"); v != "" {
+		if parsed, err := strconv.Atoi(v); err == nil && parsed >= 1 && parsed <= 100 {
+			limit = parsed
+		}
+	}
+	if v := c.QueryParam("offset"); v != "" {
+		if parsed, err := strconv.Atoi(v); err == nil && parsed >= 0 {
+			offset = parsed
+		}
+	}
+
+	params := domain.PaginationParams{Limit: limit, Offset: offset}
+
+	lps, urls, total, err := h.lessonPlanService.ListLessonPlansWithSignedURLs(ctx, userID, params)
 	if err != nil {
 		return handleDomainError(c, err)
 	}
 
-	return c.JSON(http.StatusOK, response.FromDomainLessonPlanListWithURLs(lps, urls))
+	return c.JSON(http.StatusOK, response.PaginatedLessonPlanResponse{
+		Items:  response.FromDomainLessonPlanListWithURLs(lps, urls),
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	})
 }
 
 // GetByID godoc
@@ -165,4 +194,37 @@ func (h *LessonPlanHandler) GetAnalysis(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, response.FromDomainAnalysisStatus(analysisStatus))
+}
+
+// Delete godoc
+// @Summary Delete a lesson plan
+// @Description Deletes a lesson plan, its file, and associated analyses.
+// @Tags Lesson Plans
+// @Produce json
+// @Security BearerAuth
+// @Param id path string true "Lesson plan ID"
+// @Success 204 "No Content"
+// @Failure 400 {object} response.ErrorMessageResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 404 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
+// @Router /lesson-plans/{id} [delete]
+func (h *LessonPlanHandler) Delete(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid id format"})
+	}
+
+	userID, err := getUserIDFromContext(c)
+	if err != nil {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+	}
+
+	if err := h.lessonPlanService.DeleteLessonPlan(ctx, userID, id); err != nil {
+		return handleDomainError(c, err)
+	}
+
+	return c.NoContent(http.StatusNoContent)
 }

--- a/internal/api/handlers/mocks/mock_lesson_plan_manager.go
+++ b/internal/api/handlers/mocks/mock_lesson_plan_manager.go
@@ -52,6 +52,35 @@ func (mr *MockLessonPlanManagerMockRecorder) CreateLessonPlan(ctx, lp, fileReade
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLessonPlan", reflect.TypeOf((*MockLessonPlanManager)(nil).CreateLessonPlan), ctx, lp, fileReader, filename, contentType)
 }
 
+// DeleteLessonPlan mocks base method.
+func (m *MockLessonPlanManager) DeleteLessonPlan(ctx context.Context, userID, lessonPlanID uuid.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteLessonPlan", ctx, userID, lessonPlanID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteLessonPlan indicates an expected call of DeleteLessonPlan.
+func (mr *MockLessonPlanManagerMockRecorder) DeleteLessonPlan(ctx, userID, lessonPlanID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLessonPlan", reflect.TypeOf((*MockLessonPlanManager)(nil).DeleteLessonPlan), ctx, userID, lessonPlanID)
+}
+
+// GetAnalysisStatus mocks base method.
+func (m *MockLessonPlanManager) GetAnalysisStatus(ctx context.Context, lessonPlanID uuid.UUID) (*domain.LessonPlanAnalysisStatus, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAnalysisStatus", ctx, lessonPlanID)
+	ret0, _ := ret[0].(*domain.LessonPlanAnalysisStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAnalysisStatus indicates an expected call of GetAnalysisStatus.
+func (mr *MockLessonPlanManagerMockRecorder) GetAnalysisStatus(ctx, lessonPlanID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAnalysisStatus", reflect.TypeOf((*MockLessonPlanManager)(nil).GetAnalysisStatus), ctx, lessonPlanID)
+}
+
 // GetLessonPlanWithSignedURL mocks base method.
 func (m *MockLessonPlanManager) GetLessonPlanWithSignedURL(ctx context.Context, id uuid.UUID) (*domain.LessonPlan, string, error) {
 	m.ctrl.T.Helper()
@@ -69,17 +98,18 @@ func (mr *MockLessonPlanManagerMockRecorder) GetLessonPlanWithSignedURL(ctx, id 
 }
 
 // ListLessonPlansWithSignedURLs mocks base method.
-func (m *MockLessonPlanManager) ListLessonPlansWithSignedURLs(ctx context.Context) ([]*domain.LessonPlan, map[string]string, error) {
+func (m *MockLessonPlanManager) ListLessonPlansWithSignedURLs(ctx context.Context, userID uuid.UUID, params domain.PaginationParams) ([]*domain.LessonPlan, map[string]string, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListLessonPlansWithSignedURLs", ctx)
+	ret := m.ctrl.Call(m, "ListLessonPlansWithSignedURLs", ctx, userID, params)
 	ret0, _ := ret[0].([]*domain.LessonPlan)
 	ret1, _ := ret[1].(map[string]string)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret2, _ := ret[2].(int64)
+	ret3, _ := ret[3].(error)
+	return ret0, ret1, ret2, ret3
 }
 
 // ListLessonPlansWithSignedURLs indicates an expected call of ListLessonPlansWithSignedURLs.
-func (mr *MockLessonPlanManagerMockRecorder) ListLessonPlansWithSignedURLs(ctx interface{}) *gomock.Call {
+func (mr *MockLessonPlanManagerMockRecorder) ListLessonPlansWithSignedURLs(ctx, userID, params interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLessonPlansWithSignedURLs", reflect.TypeOf((*MockLessonPlanManager)(nil).ListLessonPlansWithSignedURLs), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLessonPlansWithSignedURLs", reflect.TypeOf((*MockLessonPlanManager)(nil).ListLessonPlansWithSignedURLs), ctx, userID, params)
 }

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -34,6 +34,7 @@ func RegisterRoutes(e *echo.Echo, c *container.Container) {
 	lPGroup.POST("", c.GetLessonPlanHandler().Create)
 	lPGroup.GET("", c.GetLessonPlanHandler().List)
 	lPGroup.GET("/:id", c.GetLessonPlanHandler().GetByID)
+	lPGroup.DELETE("/:id", c.GetLessonPlanHandler().Delete)
 	lPGroup.POST("/:lesson_plan_id/analyze", c.GetAnalysisJobHandler().Analyze)
 	lPGroup.GET("/:id/analysis", c.GetLessonPlanHandler().GetAnalysis)
 

--- a/internal/core/domain/pagination.go
+++ b/internal/core/domain/pagination.go
@@ -1,0 +1,7 @@
+package domain
+
+// PaginationParams holds limit and offset for paginated queries.
+type PaginationParams struct {
+	Limit  int
+	Offset int
+}

--- a/internal/core/interfaces/primary/lesson_plan_manager.go
+++ b/internal/core/interfaces/primary/lesson_plan_manager.go
@@ -11,6 +11,7 @@ import (
 type LessonPlanManager interface {
 	CreateLessonPlan(ctx context.Context, lp *domain.LessonPlan, fileReader io.Reader, filename, contentType string) (*domain.LessonPlan, error)
 	GetLessonPlanWithSignedURL(ctx context.Context, id uuid.UUID) (*domain.LessonPlan, string, error)
-	ListLessonPlansWithSignedURLs(ctx context.Context) ([]*domain.LessonPlan, map[string]string, error)
+	ListLessonPlansWithSignedURLs(ctx context.Context, userID uuid.UUID, params domain.PaginationParams) ([]*domain.LessonPlan, map[string]string, int64, error)
 	GetAnalysisStatus(ctx context.Context, lessonPlanID uuid.UUID) (*domain.LessonPlanAnalysisStatus, error)
+	DeleteLessonPlan(ctx context.Context, userID uuid.UUID, lessonPlanID uuid.UUID) error
 }

--- a/internal/core/interfaces/secondary/lesson_plan_loader.go
+++ b/internal/core/interfaces/secondary/lesson_plan_loader.go
@@ -10,7 +10,7 @@ import (
 type LessonPlanLoader interface {
 	InsertLessonPlan(ctx context.Context, lp *domain.LessonPlan) (uuid.UUID, error)
 	GetLessonPlanByID(ctx context.Context, id uuid.UUID) (*domain.LessonPlan, error)
-	ListLessonPlans(ctx context.Context) ([]*domain.LessonPlan, error)
+	ListLessonPlans(ctx context.Context, userID uuid.UUID, params domain.PaginationParams) ([]*domain.LessonPlan, int64, error)
 	UpdateLessonPlan(ctx context.Context, lp *domain.LessonPlan) error
 	DeleteLessonPlan(ctx context.Context, id uuid.UUID) error
 }

--- a/internal/core/services/lesson_plan_services.go
+++ b/internal/core/services/lesson_plan_services.go
@@ -139,10 +139,10 @@ func (s *LessonPlanService) GetLessonPlanWithSignedURL(ctx context.Context, id u
 	return lp, signedURL, nil
 }
 
-func (s *LessonPlanService) ListLessonPlansWithSignedURLs(ctx context.Context) ([]*domain.LessonPlan, map[string]string, error) {
-	lps, err := s.repo.ListLessonPlans(ctx)
+func (s *LessonPlanService) ListLessonPlansWithSignedURLs(ctx context.Context, userID uuid.UUID, params domain.PaginationParams) ([]*domain.LessonPlan, map[string]string, int64, error) {
+	lps, total, err := s.repo.ListLessonPlans(ctx, userID, params)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
 
 	urls := make(map[string]string, len(lps))
@@ -158,7 +158,43 @@ func (s *LessonPlanService) ListLessonPlansWithSignedURLs(ctx context.Context) (
 		urls[lp.ID.String()] = signed
 	}
 
-	return lps, urls, nil
+	return lps, urls, total, nil
+}
+
+func (s *LessonPlanService) DeleteLessonPlan(ctx context.Context, userID uuid.UUID, lessonPlanID uuid.UUID) error {
+	if lessonPlanID == uuid.Nil {
+		return domain_errors.NewBadRequestMsg("lesson plan id is required")
+	}
+
+	lp, err := s.repo.GetLessonPlanByID(ctx, lessonPlanID)
+	if err != nil {
+		return err
+	}
+	if lp.UserID != userID {
+		return domain_errors.NewNotFoundMsg("lesson plan not found")
+	}
+
+	if err := s.storage.Delete(ctx, lp.FilePath); err != nil {
+		logger.Log.Error("failed to delete file from storage, proceeding with db deletion",
+			zap.Error(err),
+			zap.String("lesson_plan_id", lessonPlanID.String()),
+			zap.String("file_path", lp.FilePath),
+		)
+	}
+
+	if err := s.repo.DeleteLessonPlan(ctx, lessonPlanID); err != nil {
+		logger.Log.Error("failed to delete lesson plan from db",
+			zap.Error(err),
+			zap.String("lesson_plan_id", lessonPlanID.String()),
+		)
+		return err
+	}
+
+	logger.Log.Info("lesson plan deleted",
+		zap.String("lesson_plan_id", lessonPlanID.String()),
+		zap.String("user_id", userID.String()),
+	)
+	return nil
 }
 
 func (s *LessonPlanService) GetAnalysisStatus(ctx context.Context, lessonPlanID uuid.UUID) (*domain.LessonPlanAnalysisStatus, error) {

--- a/internal/infra/postgres/lesson_plan_repository.go
+++ b/internal/infra/postgres/lesson_plan_repository.go
@@ -65,19 +65,50 @@ func (r *LessonPlanRepository) GetLessonPlanByID(ctx context.Context, id uuid.UU
 	return m.ToDomain(), nil
 }
 
-func (r *LessonPlanRepository) ListLessonPlans(ctx context.Context) ([]*domain.LessonPlan, error) {
-	logger.Log.Debug("listing lesson plans")
-	var dbModels []models.LessonPlanModel
-	if err := r.db.WithContext(ctx).Order("created_at desc").Find(&dbModels).Error; err != nil {
-		logger.Log.Error("failed to list lesson plans", zap.Error(err))
-		return nil, domain_errors.WrapUnexpectedMsg(err, "failed to list lesson plans")
+func (r *LessonPlanRepository) ListLessonPlans(ctx context.Context, userID uuid.UUID, params domain.PaginationParams) ([]*domain.LessonPlan, int64, error) {
+	logger.Log.Debug("listing lesson plans",
+		zap.String("user_id", userID.String()),
+		zap.Int("limit", params.Limit),
+		zap.Int("offset", params.Offset),
+	)
+
+	var total int64
+	if err := r.db.WithContext(ctx).
+		Model(&models.LessonPlanModel{}).
+		Where("user_id = ?", userID).
+		Count(&total).Error; err != nil {
+		logger.Log.Error("failed to count lesson plans", zap.Error(err), zap.String("user_id", userID.String()))
+		return nil, 0, domain_errors.WrapUnexpectedMsg(err, "failed to count lesson plans")
 	}
-	logger.Log.Info("lesson plans listed", zap.Int("count", len(dbModels)))
+
+	var dbModels []models.LessonPlanModel
+	query := r.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Order("created_at desc")
+
+	if params.Limit > 0 {
+		query = query.Limit(params.Limit)
+	}
+	if params.Offset > 0 {
+		query = query.Offset(params.Offset)
+	}
+
+	if err := query.Find(&dbModels).Error; err != nil {
+		logger.Log.Error("failed to list lesson plans", zap.Error(err), zap.String("user_id", userID.String()))
+		return nil, 0, domain_errors.WrapUnexpectedMsg(err, "failed to list lesson plans")
+	}
+
+	logger.Log.Info("lesson plans listed",
+		zap.String("user_id", userID.String()),
+		zap.Int("count", len(dbModels)),
+		zap.Int64("total", total),
+	)
+
 	out := make([]*domain.LessonPlan, len(dbModels))
 	for i := range dbModels {
 		out[i] = dbModels[i].ToDomain()
 	}
-	return out, nil
+	return out, total, nil
 }
 
 func (r *LessonPlanRepository) UpdateLessonPlan(ctx context.Context, lp *domain.LessonPlan) error {

--- a/internal/infra/queue/job_manager_test.go
+++ b/internal/infra/queue/job_manager_test.go
@@ -75,8 +75,8 @@ func (m *mockLessonPlanLoader) GetLessonPlanByID(ctx context.Context, id uuid.UU
 	}, nil
 }
 
-func (m *mockLessonPlanLoader) ListLessonPlans(ctx context.Context) ([]*domain.LessonPlan, error) {
-	return nil, nil
+func (m *mockLessonPlanLoader) ListLessonPlans(ctx context.Context, userID uuid.UUID, params domain.PaginationParams) ([]*domain.LessonPlan, int64, error) {
+	return nil, 0, nil
 }
 
 func (m *mockLessonPlanLoader) UpdateLessonPlan(ctx context.Context, lp *domain.LessonPlan) error {


### PR DESCRIPTION
## Summary
- Adiciona `DELETE /lesson-plans/:id` com validação de ownership, remoção no Storage e cascade no banco
- Adiciona paginação (`limit`/`offset` + `total`) em `GET /lesson-plans`, filtrando por usuário autenticado
- Atualiza Swagger, mocks e `make run`

## Test plan
- [x] `GET /lesson-plans` retorna `{ items, total, limit, offset }`
- [x] `DELETE /lesson-plans/:id` retorna 204 e remove o plano
- [x] Delete de plano inexistente ou de outro usuário retorna 404