### PR TITLE
feat: implement secure WebSocket architecture with single-use ticket

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.3
 	github.com/jackc/pgx/v5 v5.7.4
 	github.com/joho/godotenv v1.5.1
 	github.com/labstack/echo/v4 v4.13.3
@@ -17,6 +18,7 @@ require (
 	github.com/swaggo/echo-swagger v1.5.2
 	github.com/swaggo/swag v1.16.2
 	go.uber.org/zap v1.27.1
+	golang.org/x/sync v0.19.0
 	gorm.io/datatypes v1.2.7
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.31.1
@@ -56,7 +58,6 @@ require (
 	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/time v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 h1:z2ogiKUYzX5Is6zr/v
 github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83/go.mod h1:MxpfABSjhmINe3F1It9d+8exIHFvUqtLIRCdOGNXqiI=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/internal/api/container/container.go
+++ b/internal/api/container/container.go
@@ -3,7 +3,9 @@ package container
 import (
 	"fmt"
 	"sync"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/misalima/edunex-backend/cmd/app/config"
 	"github.com/misalima/edunex-backend/internal/api/handlers"
 	"github.com/misalima/edunex-backend/internal/core/interfaces/primary"
@@ -14,6 +16,7 @@ import (
 	"github.com/misalima/edunex-backend/internal/infra/queue"
 	"github.com/misalima/edunex-backend/internal/infra/security"
 	supabase "github.com/misalima/edunex-backend/internal/infra/storage"
+	wsInfra "github.com/misalima/edunex-backend/internal/infra/websocket"
 	"gorm.io/gorm"
 )
 
@@ -54,6 +57,15 @@ type Container struct {
 
 	analysisJobHdlOnce sync.Once
 	analysisJobHdl     *handlers.AnalysisJobHandler
+
+	wsHubOnce sync.Once
+	wsHub     *wsInfra.Hub
+
+	wsTicketsOnce sync.Once
+	wsTickets     *wsInfra.TicketStore
+
+	wsHdlOnce sync.Once
+	wsHandler *handlers.WsHandler
 }
 
 func NewContainer(db *gorm.DB, cfg *config.Config) *Container {
@@ -182,7 +194,7 @@ func (c *Container) GetJobManager() *queue.JobManager {
 		analysisRepo := postgres.NewLessonPlanAnalysisRepository(c.db)
 		analysisJobRepo := postgres.NewAnalysisJobRepository(c.db)
 
-		c.jobManager = queue.NewJobManager(
+		jm := queue.NewJobManager(
 			c.db,
 			c.cfg.DBURL,
 			cfg,
@@ -192,6 +204,19 @@ func (c *Container) GetJobManager() *queue.JobManager {
 			analysisRepo,
 			analysisJobRepo,
 		)
+
+		// Injeta o callback que conecta o JobManager ao WebSocket Hub
+		hub := c.GetWsHub()
+		jm.SetStatusUpdateCallback(func(userID, lessonPlanID uuid.UUID, status string) {
+			hub.BroadcastToUser(userID, map[string]interface{}{
+				"type":           "analysis_status",
+				"lesson_plan_id": lessonPlanID.String(),
+				"status":         status,
+				"timestamp":      time.Now().Format(time.RFC3339),
+			})
+		})
+
+		c.jobManager = jm
 	})
 	return c.jobManager
 }
@@ -204,9 +229,34 @@ func (c *Container) GetAnalysisJobHandler() *handlers.AnalysisJobHandler {
 	return c.analysisJobHdl
 }
 
+func (c *Container) GetWsHub() *wsInfra.Hub {
+	c.wsHubOnce.Do(func() {
+		c.wsHub = wsInfra.NewHub()
+		c.wsHub.Start() // Inicia o event loop do Hub de WS
+	})
+	return c.wsHub
+}
+
+func (c *Container) GetWsTicketStore() *wsInfra.TicketStore {
+	c.wsTicketsOnce.Do(func() {
+		c.wsTickets = wsInfra.NewTicketStore()
+	})
+	return c.wsTickets
+}
+
+func (c *Container) GetWsHandler() *handlers.WsHandler {
+	c.wsHdlOnce.Do(func() {
+		c.wsHandler = handlers.NewWsHandler(c.GetWsHub(), c.GetWsTicketStore())
+	})
+	return c.wsHandler
+}
+
 func (c *Container) Close() {
 	if c.authService != nil {
 		c.authService.Close()
+	}
+	if c.wsHub != nil {
+		c.wsHub.Stop()
 	}
 }
 

--- a/internal/api/handlers/ws_handler.go
+++ b/internal/api/handlers/ws_handler.go
@@ -77,7 +77,7 @@ func (h *WsHandler) ConnectWs(c echo.Context) error {
 	client := wsInfra.NewClient(h.hub, wsConn, userID)
 	if !h.hub.Register(client) {
 		logger.Log.Warn("WS hub is stopped, rejecting connection", zap.String("user_id", userID.String()))
-		wsConn.Close()
+		_ = wsConn.Close()
 		return nil
 	}
 

--- a/internal/api/handlers/ws_handler.go
+++ b/internal/api/handlers/ws_handler.go
@@ -1,0 +1,88 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gorilla/websocket"
+	"github.com/labstack/echo/v4"
+	"github.com/misalima/edunex-backend/internal/infra/logger"
+	wsInfra "github.com/misalima/edunex-backend/internal/infra/websocket"
+	"go.uber.org/zap"
+)
+
+type WsHandler struct {
+	hub        *wsInfra.Hub
+	tickets    *wsInfra.TicketStore
+	upgrader   websocket.Upgrader
+}
+
+func NewWsHandler(hub *wsInfra.Hub, tickets *wsInfra.TicketStore) *WsHandler {
+	return &WsHandler{
+		hub:     hub,
+		tickets: tickets,
+		upgrader: websocket.Upgrader{
+			ReadBufferSize:  1024,
+			WriteBufferSize: 1024,
+			CheckOrigin: func(r *http.Request) bool {
+				// Permitir todas as origens para facilidade no dev/local.
+				// Next.js (client) fará a requisição a partir de portas locais distintas.
+				return true
+			},
+		},
+	}
+}
+
+// IssueTicket godoc
+// @Summary Issue a short-lived WebSocket ticket
+// @Description Exchanges a Bearer JWT for a single-use WS ticket (TTL ~30s). Use the ticket as ?ticket= on the WebSocket URL — never put the JWT in the query string.
+// @Tags WebSocket
+// @Produce json
+// @Security BearerAuth
+// @Success 200 {object} map[string]string
+// @Failure 401 {object} map[string]string
+// @Failure 500 {object} map[string]string
+// @Router /ws/ticket [post]
+func (h *WsHandler) IssueTicket(c echo.Context) error {
+	userID, err := getUserIDFromContext(c)
+	if err != nil {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+	}
+
+	ticket, err := h.tickets.Issue(userID)
+	if err != nil {
+		logger.Log.Error("failed to issue WS ticket", zap.Error(err), zap.String("user_id", userID.String()))
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to issue ticket"})
+	}
+
+	return c.JSON(http.StatusOK, map[string]string{
+		"ticket": ticket,
+	})
+}
+
+// ConnectWs Upgrade HTTP -> WebSocket after consuming a one-time ticket.
+func (h *WsHandler) ConnectWs(c echo.Context) error {
+	ticket := c.QueryParam("ticket")
+	userID, ok := h.tickets.Consume(ticket)
+	if !ok {
+		logger.Log.Warn("WS connection attempt blocked: invalid or expired ticket")
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "invalid or expired ticket"})
+	}
+
+	wsConn, err := h.upgrader.Upgrade(c.Response(), c.Request(), nil)
+	if err != nil {
+		logger.Log.Error("failed to upgrade to websocket connection", zap.Error(err))
+		return err
+	}
+
+	client := wsInfra.NewClient(h.hub, wsConn, userID)
+	if !h.hub.Register(client) {
+		logger.Log.Warn("WS hub is stopped, rejecting connection", zap.String("user_id", userID.String()))
+		wsConn.Close()
+		return nil
+	}
+
+	go client.WritePump()
+	go client.ReadPump()
+
+	return nil
+}

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -14,9 +14,13 @@ func RegisterRoutes(e *echo.Echo, c *container.Container) {
 	// Rotas públicas
 	e.GET("/health", c.GetHealthHandler().HealthHandler)
 
+	// WebSocket: ticket is a short-lived single-use token (never put the JWT in the URL).
+	e.GET("/api/v1/ws/lesson-plans", c.GetWsHandler().ConnectWs)
+
 	v1 := e.Group("/api/v1")
 	v1.Use(middleware.AuthMiddleware(c.GetAuthenticator()))
 	v1.GET("/me", c.GetUserHandler().GetMe)
+	v1.POST("/ws/ticket", c.GetWsHandler().IssueTicket)
 
 	// Users
 	userGroup := v1.Group("/users")

--- a/internal/core/services/lesson_plan_services.go
+++ b/internal/core/services/lesson_plan_services.go
@@ -170,6 +170,9 @@ func (s *LessonPlanService) DeleteLessonPlan(ctx context.Context, userID uuid.UU
 	if err != nil {
 		return err
 	}
+	if lp == nil {
+		return domain_errors.NewNotFoundMsg("lesson plan not found")
+	}
 	if lp.UserID != userID {
 		return domain_errors.NewNotFoundMsg("lesson plan not found")
 	}

--- a/internal/infra/queue/job_manager.go
+++ b/internal/infra/queue/job_manager.go
@@ -34,6 +34,9 @@ func DefaultJobManagerConfig() *JobManagerConfig {
 	}
 }
 
+// StatusUpdateCallback is triggered when a job transitions its state.
+type StatusUpdateCallback func(userID uuid.UUID, lessonPlanID uuid.UUID, status string)
+
 // JobManager orchestrates job processing with worker pool and notification system
 type JobManager struct {
 	db              *gorm.DB
@@ -52,6 +55,7 @@ type JobManager struct {
 	isRunning       bool
 	metrics         *JobMetrics
 	pollTicker      *time.Ticker
+	onStatusUpdate  StatusUpdateCallback
 	mu              sync.RWMutex
 }
 
@@ -94,6 +98,13 @@ func NewJobManager(
 		cancel:          cancel,
 		metrics:         &JobMetrics{},
 	}
+}
+
+// SetStatusUpdateCallback sets the status update callback.
+func (jm *JobManager) SetStatusUpdateCallback(cb StatusUpdateCallback) {
+	jm.mu.Lock()
+	defer jm.mu.Unlock()
+	jm.onStatusUpdate = cb
 }
 
 // Start initializes the worker pool and notification listener
@@ -314,6 +325,14 @@ func (jm *JobManager) processJobWithData(job *domain.AnalysisJob, workerID int) 
 		return
 	}
 
+	// Trigger broadcast to websocket that analysis is active in a worker
+	jm.mu.RLock()
+	cb := jm.onStatusUpdate
+	jm.mu.RUnlock()
+	if cb != nil {
+		cb(lessonPlan.UserID, job.LessonPlanID, "processing")
+	}
+
 	// Extract content from file
 	content, err := jm.extractors.ExtractFromStorage(jm.ctx, lessonPlan.FilePath)
 	if err != nil {
@@ -349,6 +368,14 @@ func (jm *JobManager) processJobWithData(job *domain.AnalysisJob, workerID int) 
 		return
 	}
 
+	// Trigger broadcast that analysis finished successfully
+	jm.mu.RLock()
+	cb = jm.onStatusUpdate
+	jm.mu.RUnlock()
+	if cb != nil {
+		cb(lessonPlan.UserID, job.LessonPlanID, "done")
+	}
+
 	jm.metrics.SuccessfulJobs.Add(1)
 	jm.metrics.ProcessedJobs.Add(1)
 
@@ -368,6 +395,24 @@ func (jm *JobManager) handleJobFailure(jobID uuid.UUID, errorMsg string) {
 
 	jm.metrics.FailedJobs.Add(1)
 	jm.metrics.ProcessedJobs.Add(1)
+
+	// Fetch job to get lessonPlanID and check owner user for websocket notify
+	if job, err := jm.analysisJobRepo.GetJobByID(jm.ctx, jobID); err == nil && job != nil {
+		if lp, err := jm.lessonPlanRepo.GetLessonPlanByID(jm.ctx, job.LessonPlanID); err == nil && lp != nil {
+			jm.mu.RLock()
+			cb := jm.onStatusUpdate
+			jm.mu.RUnlock()
+			if cb != nil {
+				// Se atingiu o número máximo de tentativas, sinaliza como "failed" definitivo.
+				// Caso contrário, continua como "pending" (esperando retry)
+				status := "failed"
+				if job.Attempts < jm.config.MaxAttempts {
+					status = "pending"
+				}
+				cb(lp.UserID, lp.ID, status)
+			}
+		}
+	}
 }
 
 // pollFallback periodically polls for pending jobs as a fallback when notifications fail.

--- a/internal/infra/websocket/client.go
+++ b/internal/infra/websocket/client.go
@@ -74,13 +74,18 @@ func (c *Client) closeSend() {
 func (c *Client) ReadPump() {
 	defer func() {
 		c.hub.Unregister(c)
-		c.conn.Close()
+		_ = c.conn.Close()
 	}()
 
 	c.conn.SetReadLimit(maxMessageSize)
-	c.conn.SetReadDeadline(time.Now().Add(pongWait))
+	if err := c.conn.SetReadDeadline(time.Now().Add(pongWait)); err != nil {
+		logger.Log.Error("WS failed to set read deadline", zap.Error(err), zap.String("user_id", c.userID.String()))
+		return
+	}
 	c.conn.SetPongHandler(func(string) error {
-		c.conn.SetReadDeadline(time.Now().Add(pongWait))
+		if err := c.conn.SetReadDeadline(time.Now().Add(pongWait)); err != nil {
+			return err
+		}
 		return nil
 	})
 
@@ -100,39 +105,62 @@ func (c *Client) WritePump() {
 	ticker := time.NewTicker(pingPeriod)
 	defer func() {
 		ticker.Stop()
-		c.conn.Close()
+		_ = c.conn.Close()
 	}()
 
 	for {
 		select {
 		case message, ok := <-c.send:
-			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if err := c.conn.SetWriteDeadline(time.Now().Add(writeWait)); err != nil {
+				logger.Log.Error("WS failed to set write deadline", zap.Error(err), zap.String("user_id", c.userID.String()))
+				return
+			}
 			if !ok {
 				// O Hub fechou o canal send
-				c.conn.WriteMessage(websocket.CloseMessage, []byte{})
+				if err := c.conn.WriteMessage(websocket.CloseMessage, []byte{}); err != nil {
+					logger.Log.Debug("WS failed to write close message", zap.Error(err), zap.String("user_id", c.userID.String()))
+				}
 				return
 			}
 
 			w, err := c.conn.NextWriter(websocket.TextMessage)
 			if err != nil {
+				logger.Log.Error("WS failed to get next writer", zap.Error(err), zap.String("user_id", c.userID.String()))
 				return
 			}
-			w.Write(message)
+			if _, err := w.Write(message); err != nil {
+				logger.Log.Error("WS failed to write message", zap.Error(err), zap.String("user_id", c.userID.String()))
+				_ = w.Close()
+				return
+			}
 
 			// Consome mensagens extras enfileiradas no mesmo tick
 			n := len(c.send)
 			for i := 0; i < n; i++ {
-				w.Write([]byte{'\n'})
-				w.Write(<-c.send)
+				if _, err := w.Write([]byte{'\n'}); err != nil {
+					logger.Log.Error("WS failed to write message separator", zap.Error(err), zap.String("user_id", c.userID.String()))
+					_ = w.Close()
+					return
+				}
+				if _, err := w.Write(<-c.send); err != nil {
+					logger.Log.Error("WS failed to write queued message", zap.Error(err), zap.String("user_id", c.userID.String()))
+					_ = w.Close()
+					return
+				}
 			}
 
 			if err := w.Close(); err != nil {
+				logger.Log.Error("WS failed to close writer", zap.Error(err), zap.String("user_id", c.userID.String()))
 				return
 			}
 
 		case <-ticker.C:
-			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if err := c.conn.SetWriteDeadline(time.Now().Add(writeWait)); err != nil {
+				logger.Log.Error("WS failed to set write deadline for ping", zap.Error(err), zap.String("user_id", c.userID.String()))
+				return
+			}
 			if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				logger.Log.Error("WS failed to write ping", zap.Error(err), zap.String("user_id", c.userID.String()))
 				return
 			}
 		}

--- a/internal/infra/websocket/client.go
+++ b/internal/infra/websocket/client.go
@@ -1,0 +1,140 @@
+package websocket
+
+import (
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+	"github.com/misalima/edunex-backend/internal/infra/logger"
+	"go.uber.org/zap"
+)
+
+const (
+	// Tempo permitido para escrever uma mensagem no peer
+	writeWait = 10 * time.Second
+
+	// Tempo permitido para ler o próximo pong do peer
+	pongWait = 60 * time.Second
+
+	// Período de envio de pings ao peer (deve ser menor que pongWait)
+	pingPeriod = (pongWait * 9) / 10
+
+	// Tamanho máximo da mensagem recebida do peer (não esperamos comandos, apenas batimentos)
+	maxMessageSize = 512
+)
+
+type Client struct {
+	hub    *Hub
+	conn   *websocket.Conn
+	userID uuid.UUID
+	send   chan []byte
+
+	mu     sync.Mutex
+	closed bool
+}
+
+func NewClient(hub *Hub, conn *websocket.Conn, userID uuid.UUID) *Client {
+	return &Client{
+		hub:    hub,
+		conn:   conn,
+		userID: userID,
+		send:   make(chan []byte, 256),
+	}
+}
+
+// trySend enfileira uma mensagem sem panic se o canal já foi fechado.
+// Retorna false se o client já foi fechado ou se o buffer está cheio.
+func (c *Client) trySend(message []byte) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return false
+	}
+	select {
+	case c.send <- message:
+		return true
+	default:
+		return false
+	}
+}
+
+// closeSend fecha o canal send no máximo uma vez.
+func (c *Client) closeSend() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return
+	}
+	c.closed = true
+	close(c.send)
+}
+
+// ReadPump lê dados da conexão. Só serve para detectar desconexão e manter o batimento
+func (c *Client) ReadPump() {
+	defer func() {
+		c.hub.Unregister(c)
+		c.conn.Close()
+	}()
+
+	c.conn.SetReadLimit(maxMessageSize)
+	c.conn.SetReadDeadline(time.Now().Add(pongWait))
+	c.conn.SetPongHandler(func(string) error {
+		c.conn.SetReadDeadline(time.Now().Add(pongWait))
+		return nil
+	})
+
+	for {
+		_, _, err := c.conn.ReadMessage()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+				logger.Log.Error("WS connection error in read pump", zap.Error(err))
+			}
+			break
+		}
+	}
+}
+
+// WritePump consome as mensagens pendentes no canal send e envia via WebSocket
+func (c *Client) WritePump() {
+	ticker := time.NewTicker(pingPeriod)
+	defer func() {
+		ticker.Stop()
+		c.conn.Close()
+	}()
+
+	for {
+		select {
+		case message, ok := <-c.send:
+			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if !ok {
+				// O Hub fechou o canal send
+				c.conn.WriteMessage(websocket.CloseMessage, []byte{})
+				return
+			}
+
+			w, err := c.conn.NextWriter(websocket.TextMessage)
+			if err != nil {
+				return
+			}
+			w.Write(message)
+
+			// Consome mensagens extras enfileiradas no mesmo tick
+			n := len(c.send)
+			for i := 0; i < n; i++ {
+				w.Write([]byte{'\n'})
+				w.Write(<-c.send)
+			}
+
+			if err := w.Close(); err != nil {
+				return
+			}
+
+		case <-ticker.C:
+			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		}
+	}
+}

--- a/internal/infra/websocket/hub.go
+++ b/internal/infra/websocket/hub.go
@@ -94,7 +94,7 @@ func (h *Hub) Stop() {
 	for userID, userClients := range h.clients {
 		for client := range userClients {
 			client.closeSend()
-			client.conn.Close()
+			_ = client.conn.Close()
 			delete(userClients, client)
 		}
 		delete(h.clients, userID)
@@ -132,6 +132,6 @@ func (h *Hub) BroadcastToUser(userID uuid.UUID, message interface{}) {
 			zap.String("user_id", userID.String()),
 			zap.String("remote_addr", client.conn.RemoteAddr().String()))
 		h.Unregister(client)
-		client.conn.Close()
+		_ = client.conn.Close()
 	}
 }

--- a/internal/infra/websocket/hub.go
+++ b/internal/infra/websocket/hub.go
@@ -1,0 +1,137 @@
+package websocket
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/misalima/edunex-backend/internal/infra/logger"
+	"go.uber.org/zap"
+)
+
+type Hub struct {
+	// Conexões registradas indexadas por userID
+	clients    map[uuid.UUID]map[*Client]bool
+	clientsMu  sync.RWMutex
+	register   chan *Client
+	unregister chan *Client
+	ctx        context.Context
+	cancel     context.CancelFunc
+}
+
+func NewHub() *Hub {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Hub{
+		clients:    make(map[uuid.UUID]map[*Client]bool),
+		register:   make(chan *Client),
+		unregister: make(chan *Client),
+		ctx:        ctx,
+		cancel:     cancel,
+	}
+}
+
+// Register enfileira o client no event loop. Retorna false se o hub já foi parado.
+func (h *Hub) Register(c *Client) bool {
+	select {
+	case <-h.ctx.Done():
+		return false
+	case h.register <- c:
+		return true
+	}
+}
+
+func (h *Hub) Unregister(c *Client) {
+	select {
+	case <-h.ctx.Done():
+		c.closeSend()
+	case h.unregister <- c:
+	}
+}
+
+func (h *Hub) Start() {
+	go func() {
+		for {
+			select {
+			case <-h.ctx.Done():
+				return
+			case client := <-h.register:
+				h.clientsMu.Lock()
+				if _, ok := h.clients[client.userID]; !ok {
+					h.clients[client.userID] = make(map[*Client]bool)
+				}
+				h.clients[client.userID][client] = true
+				h.clientsMu.Unlock()
+				logger.Log.Debug("WS Client registered",
+					zap.String("user_id", client.userID.String()),
+					zap.String("remote_addr", client.conn.RemoteAddr().String()))
+
+			case client := <-h.unregister:
+				h.clientsMu.Lock()
+				if userClients, ok := h.clients[client.userID]; ok {
+					if _, exists := userClients[client]; exists {
+						delete(userClients, client)
+						client.closeSend()
+						logger.Log.Debug("WS Client unregistered",
+							zap.String("user_id", client.userID.String()),
+							zap.String("remote_addr", client.conn.RemoteAddr().String()))
+					}
+					if len(userClients) == 0 {
+						delete(h.clients, client.userID)
+					}
+				}
+				h.clientsMu.Unlock()
+			}
+		}
+	}()
+}
+
+func (h *Hub) Stop() {
+	h.cancel()
+	h.clientsMu.Lock()
+	defer h.clientsMu.Unlock()
+
+	for userID, userClients := range h.clients {
+		for client := range userClients {
+			client.closeSend()
+			client.conn.Close()
+			delete(userClients, client)
+		}
+		delete(h.clients, userID)
+	}
+}
+
+// BroadcastToUser envia dados JSON para todas as conexões ativas de um userID
+func (h *Hub) BroadcastToUser(userID uuid.UUID, message interface{}) {
+	payload, err := json.Marshal(message)
+	if err != nil {
+		logger.Log.Error("failed to marshal WS message", zap.Error(err))
+		return
+	}
+
+	h.clientsMu.RLock()
+	userClients, ok := h.clients[userID]
+	if !ok || len(userClients) == 0 {
+		h.clientsMu.RUnlock()
+		return
+	}
+
+	// Cria uma cópia dos clients para evitar segurar o lock de leitura durante o envio lento
+	clientsCopy := make([]*Client, 0, len(userClients))
+	for client := range userClients {
+		clientsCopy = append(clientsCopy, client)
+	}
+	h.clientsMu.RUnlock()
+
+	for _, client := range clientsCopy {
+		if client.trySend(payload) {
+			continue
+		}
+		// Fechado ou buffer cheio -> desconecta sem panic em canal fechado
+		logger.Log.Warn("WS Client send dropped, unregistering client",
+			zap.String("user_id", userID.String()),
+			zap.String("remote_addr", client.conn.RemoteAddr().String()))
+		h.Unregister(client)
+		client.conn.Close()
+	}
+}

--- a/internal/infra/websocket/ticket_store.go
+++ b/internal/infra/websocket/ticket_store.go
@@ -1,0 +1,81 @@
+package websocket
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const defaultTicketTTL = 30 * time.Second
+
+// TicketStore issues short-lived, single-use tickets that map to a userID.
+// Used so the browser never puts a long-lived JWT in the WebSocket URL.
+type TicketStore struct {
+	mu      sync.Mutex
+	tickets map[string]ticketEntry
+	ttl     time.Duration
+}
+
+type ticketEntry struct {
+	userID    uuid.UUID
+	expiresAt time.Time
+}
+
+func NewTicketStore() *TicketStore {
+	return &TicketStore{
+		tickets: make(map[string]ticketEntry),
+		ttl:     defaultTicketTTL,
+	}
+}
+
+// Issue creates a new opaque ticket for userID. The ticket expires after ttl
+// and can be consumed at most once.
+func (s *TicketStore) Issue(userID uuid.UUID) (string, error) {
+	var raw [32]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", err
+	}
+	id := hex.EncodeToString(raw[:])
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.purgeExpiredLocked(time.Now())
+	s.tickets[id] = ticketEntry{
+		userID:    userID,
+		expiresAt: time.Now().Add(s.ttl),
+	}
+	return id, nil
+}
+
+// Consume validates and removes the ticket in one step (single-use).
+// Returns the associated userID and true on success.
+func (s *TicketStore) Consume(ticket string) (uuid.UUID, bool) {
+	if ticket == "" {
+		return uuid.Nil, false
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entry, ok := s.tickets[ticket]
+	if !ok {
+		return uuid.Nil, false
+	}
+	delete(s.tickets, ticket)
+
+	if time.Now().After(entry.expiresAt) {
+		return uuid.Nil, false
+	}
+	return entry.userID, true
+}
+
+func (s *TicketStore) purgeExpiredLocked(now time.Time) {
+	for id, entry := range s.tickets {
+		if now.After(entry.expiresAt) {
+			delete(s.tickets, id)
+		}
+	}
+}

--- a/internal/infra/websocket/ticket_store_test.go
+++ b/internal/infra/websocket/ticket_store_test.go
@@ -1,0 +1,55 @@
+package websocket
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestTicketStore_IssueAndConsume(t *testing.T) {
+	store := NewTicketStore()
+	userID := uuid.New()
+
+	ticket, err := store.Issue(userID)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	if ticket == "" {
+		t.Fatal("expected non-empty ticket")
+	}
+
+	got, ok := store.Consume(ticket)
+	if !ok {
+		t.Fatal("expected consume to succeed")
+	}
+	if got != userID {
+		t.Fatalf("userID: got %s want %s", got, userID)
+	}
+
+	if _, ok := store.Consume(ticket); ok {
+		t.Fatal("ticket must be single-use")
+	}
+}
+
+func TestTicketStore_Expired(t *testing.T) {
+	store := NewTicketStore()
+	store.ttl = time.Millisecond
+
+	ticket, err := store.Issue(uuid.New())
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	time.Sleep(5 * time.Millisecond)
+
+	if _, ok := store.Consume(ticket); ok {
+		t.Fatal("expired ticket must be rejected")
+	}
+}
+
+func TestTicketStore_Unknown(t *testing.T) {
+	store := NewTicketStore()
+	if _, ok := store.Consume("does-not-exist"); ok {
+		t.Fatal("unknown ticket must be rejected")
+	}
+}


### PR DESCRIPTION
## Summary
- Adiciona hub WebSocket in-memory com broadcast por `userID` e pushes de status de análise (`processing` / `done` / `pending` / `failed`) via callback do `JobManager`
- Autenticação WS por ticket de uso único (`POST /ws/ticket` com Bearer → `GET /ws/lesson-plans?ticket=…`), sem JWT na query
- Inclui ping/pong, backpressure no buffer e shutdown limpo do hub

## Test plan
- [x] `POST /api/v1/ws/ticket` com Bearer retorna `{ ticket }`
- [x] Conectar em `/api/v1/ws/lesson-plans?ticket=…` e receber eventos ao rodar uma análise
- [x] Ticket reutilizado ou expirado retorna 401
- [x] JWT na query não autentica mais o WS